### PR TITLE
Removed reference to "primary selection" from documentation of match

### DIFF
--- a/com.archimatetool.help/help/Text/view_align_grid.html
+++ b/com.archimatetool.help/help/Text/view_align_grid.html
@@ -33,35 +33,35 @@
       </tr>
       <tr valign="top">
         <td><strong>Align Left:</strong></td>
-        <td>When two or more elements are selected align on the left edge.</td>
+        <td>When two or more elements are selected align on the left edge of the last selected element.</td>
       </tr>
       <tr valign="top">
         <td><strong>Align Center:</strong></td>
-        <td>When two or more elements are selected align centrally horizontally.</td>
+        <td>When two or more elements are selected align centrally horizontally to the last selected element.</td>
       </tr>
       <tr valign="top">
         <td><strong>Align Right:</strong></td>
-        <td>When two or more elements are selected align on the right edge.</td>
+        <td>When two or more elements are selected align on the right edge to the last selected element.</td>
       </tr>
       <tr valign="top">
         <td><strong>Align Top:</strong></td>
-        <td>When two or more elements are selected align on the top edge.</td>
+        <td>When two or more elements are selected align on the top edge of the last selected element.</td>
       </tr>
       <tr valign="top">
         <td><strong>Align Middle:</strong></td>
-        <td>When two or more elements are selected align centrally vertically.</td>
+        <td>When two or more elements are selected align centrally vertically to the last selected element.</td>
       </tr>
       <tr valign="top">
         <td><strong>Align Bottom:</strong></td>
-        <td>When two or more elements are selected align on the bottom edge.</td>
+        <td>When two or more elements are selected align on the bottom edge of the last selected element.</td>
       </tr>
       <tr valign="top">
         <td><strong>Match Width:</strong></td>
-        <td>When two or more elements are selected match the width of the elements to the primary selection.</td>
+        <td>When two or more elements are selected match the width of the elements to the last selected element.</td>
       </tr>
       <tr valign="top">
         <td><strong>Match Height:</strong></td>
-        <td>When two or more elements are selected match the height of the elements to the primary selection.</td>
+        <td>When two or more elements are selected match the height of the elements to the last selected element.</td>
       </tr>
       <tr valign="top">
         <td><strong>Default Size:</strong></td>


### PR DESCRIPTION
and align actions, as this concept is not used anywhere else in the
docs. Changed all align and match descriptions to explicitly state
that alignment and match is performed with reference to the last
selected element (as opposed to e.g. the first, which "primary
selection" might lead some people (_cough_) to believe).
