### PR TITLE
Include a link to the wiki about contributing code to Archi, for easy reference from GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,7 @@ All developer resources are here:
 
 [http://www.archimatetool.com/developer](http://www.archimatetool.com/developer)
 
+
+## Contributing code to Archi
+
+Please see [How can I contribute code to Archi](https://github.com/Phillipus/archi/wiki/How-can-I-contribute-code-to-Archi)


### PR DESCRIPTION
Very small change, just to make it easier for user entering via GitHub.
