### PR TITLE
Update the documentation for connection routers

### DIFF
--- a/com.archimatetool.help/help/Text/prefs_connections.html
+++ b/com.archimatetool.help/help/Text/prefs_connections.html
@@ -41,7 +41,7 @@
         <br/>On Windows and Linux operating systems ensures that connections are drawn more smoothly.
     </p>
 	
-	<p><strong>Use orthogonal connection anchors</strong><br/>
+	<p><strong><a id="useorthogonalconnectionanchors">Use orthogonal connection anchors</a></strong><br/>
 	If this is ticked then a new method to calculate the anchor point for a connection is used (the position where a connection connects to a figure). By default (option not ticked), the anchor point is computed as the intersection of the figure's border and the connection targeting the figure's centre. With this option, the anchor point is computed to make the connection either a vertical or horizontal line (if this not possible, it connects to one of the figure's corners). It is possible to move this anchor point just by moving the figure or by creating a bend point in the connection and moving that.</p>
 	<p>For example if not ticked (default) the connections appear as follows:</p>
 	<img src="../Images/orthogonal1.png" alt="Orthogonal 1"/>

--- a/com.archimatetool.help/help/Text/view_conn_router.html
+++ b/com.archimatetool.help/help/Text/view_conn_router.html
@@ -15,6 +15,8 @@
     <p>By default, connections are drawn as straight lines from element to element. Bend-points can be added to a connection as detailed <a href="view_conn_bendpoints.html">here</a>. However, it is possible to set the overall connection router type so that the connections route around elements or are drawn orthogonally.</p>
     
     <p>The connection router type can be set either from the main "View-&gt;Connection Router" menu or by right-clicking on a View or from the "Appearance" tab in the <a href="properties_view.html">Properties Window</a> when the View canvas is selected.</p>
+
+    <p class="boxout"><img src="../Images/tip.png" class="tipImage"/>Apart from the view specific settings, the global setting <a href="prefs_connections.html#useorthogonalconnectionanchors">Use orthogonal connection anchors</a> from the <a href="prefs_connections.html">Connection Preferences</a> tab can be used to change the way connections are drawn.</p>
     
     <p>The available router types are as follows:</p>
     


### PR DESCRIPTION
to include a tip about orthogonal connections to elements.

Motivation: I missed the orthogonal connections to elements the first time around (when I read through the entire documentation), so I think a tip is in order.
