### PR TITLE
RFC: Merge feature

### DIFF
--- a/com.archimatetool.editor/src/com/archimatetool/editor/diagram/AbstractDiagramEditor.java
+++ b/com.archimatetool.editor/src/com/archimatetool/editor/diagram/AbstractDiagramEditor.java
@@ -88,6 +88,7 @@ import com.archimatetool.editor.diagram.actions.FontColorAction;
 import com.archimatetool.editor.diagram.actions.FullScreenAction;
 import com.archimatetool.editor.diagram.actions.LineColorAction;
 import com.archimatetool.editor.diagram.actions.LockObjectAction;
+import com.archimatetool.editor.diagram.actions.MergeAction;
 import com.archimatetool.editor.diagram.actions.PasteAction;
 import com.archimatetool.editor.diagram.actions.PrintDiagramAction;
 import com.archimatetool.editor.diagram.actions.PropertiesAction;
@@ -548,19 +549,24 @@ implements IDiagramModelEditor, IContextProvider, ITabbedPropertySheetPageContri
         action.setToolTipText(action.getText());
         getUpdateCommandStackActions().add((UpdateAction)action);
         
+        // Merge
+        MergeAction mergeAction = new MergeAction(this, viewer);
+        registry.registerAction(mergeAction);
+        getSelectionActions().add(mergeAction.getId());
+
         // Paste
         PasteAction pasteAction = new PasteAction(this, viewer);
         registry.registerAction(pasteAction);
         getSelectionActions().add(pasteAction.getId());
         
         // Cut
-        action = new CutAction(this, pasteAction);
+        action = new CutAction(this, pasteAction, mergeAction);
         registry.registerAction(action);
         getSelectionActions().add(action.getId());
         getUpdateCommandStackActions().add((UpdateAction)action);
         
         // Copy
-        action = new CopyAction(this, pasteAction);
+        action = new CopyAction(this, pasteAction, mergeAction);
         registry.registerAction(action);
         getSelectionActions().add(action.getId());
         getUpdateCommandStackActions().add((UpdateAction)action);

--- a/com.archimatetool.editor/src/com/archimatetool/editor/diagram/AbstractDiagramEditorContextMenuProvider.java
+++ b/com.archimatetool.editor/src/com/archimatetool/editor/diagram/AbstractDiagramEditorContextMenuProvider.java
@@ -23,6 +23,7 @@ import com.archimatetool.editor.diagram.actions.DefaultEditPartSizeAction;
 import com.archimatetool.editor.diagram.actions.ExportAsImageAction;
 import com.archimatetool.editor.diagram.actions.ExportAsImageToClipboardAction;
 import com.archimatetool.editor.diagram.actions.LockObjectAction;
+import com.archimatetool.editor.diagram.actions.MergeAction;
 import com.archimatetool.editor.diagram.actions.SelectElementInTreeAction;
 import com.archimatetool.editor.diagram.actions.SendBackwardAction;
 import com.archimatetool.editor.diagram.actions.SendToBackAction;
@@ -82,6 +83,9 @@ public abstract class AbstractDiagramEditorContextMenuProvider extends ContextMe
         menu.appendToGroup(GROUP_EDIT, action);
         
         action = actionRegistry.getAction(ActionFactory.PASTE.getId());
+        menu.appendToGroup(GROUP_EDIT, action);
+
+        action = actionRegistry.getAction(MergeAction.ID);
         menu.appendToGroup(GROUP_EDIT, action);
         
         action = actionRegistry.getAction(ActionFactory.DELETE.getId());

--- a/com.archimatetool.editor/src/com/archimatetool/editor/diagram/actions/CopyAction.java
+++ b/com.archimatetool.editor/src/com/archimatetool/editor/diagram/actions/CopyAction.java
@@ -29,10 +29,12 @@ import com.archimatetool.model.ILockable;
 public class CopyAction extends SelectionAction {
     
     protected PasteAction fPasteAction;
+    protected MergeAction fMergeAction;
     
-    public CopyAction(IWorkbenchPart part, PasteAction pasteAction) {
+    public CopyAction(IWorkbenchPart part, PasteAction pasteAction, MergeAction mergeAction) {
         super(part);
         fPasteAction = pasteAction;
+        fMergeAction = mergeAction;
     }
     
     @Override
@@ -89,7 +91,8 @@ public class CopyAction extends SelectionAction {
         CopySnapshot clipBoardCopy = new CopySnapshot(modelObjectsSelected);
         Clipboard.getDefault().setContents(clipBoardCopy);
         
-        // Reset Paste Action
+        // Reset Paste and Merge Actions
         fPasteAction.reset();
+        fMergeAction.reset();
     }
 }

--- a/com.archimatetool.editor/src/com/archimatetool/editor/diagram/actions/CopySnapshot.java
+++ b/com.archimatetool.editor/src/com/archimatetool/editor/diagram/actions/CopySnapshot.java
@@ -276,7 +276,11 @@ public final class CopySnapshot {
     }
     
     /**
-     * @param targetDiagramModel
+     * Checks if any of the objects in this CopySnapshot instance can be pasted to a target diagram model.
+     * 
+     * The targetDiagramModel most be the same type as the objects was copied from.   
+     * 
+     * @param targetDiagramModel The diagram model to paste to
      * @return true if at least one copied object can be pasted to target diagram model
      */
     public boolean canPasteToDiagram(IDiagramModel targetDiagramModel) {
@@ -314,8 +318,12 @@ public final class CopySnapshot {
     }
     
     /*
-     * @return True if the target diagram model already contains at least one reference to the copied Archimate Elements.
-     * If this is true then we need to paste copies.
+     * Check if the paste need to copy the diagram elements in a selection, instead of referencing the existing (archimate?) elements.
+     * 
+     * A copy must be made if the target and source archimate models are different (as references can not be made between archimate models).
+     * A copy must also be med if one or more of the reference archimate model elements have been deleted, or if one or elements are already referenced in the target diagram model.  
+     * 
+     * @return True if a copy must be made, false otherwise
      */
     private boolean needsCopiedArchimateElements(IDiagramModel targetDiagramModel) {
         // If different Archimate Models then yes!
@@ -351,6 +359,10 @@ public final class CopySnapshot {
     }
     
     /**
+     * Create a Command to paste the contents of this CopySnapShot instance to the target diagram model.
+     * 
+     * This is command used by the PasteAction to actually perform the paste.
+     * 
      * @param targetDiagramModel The diagram model to paste to
      * @param viewer An optional GraphicalViewer to select the pasted object
      * @param mousePosition position of mouse clicked in viewer or null if no mouse click

--- a/com.archimatetool.editor/src/com/archimatetool/editor/diagram/actions/CopySnapshot.java
+++ b/com.archimatetool.editor/src/com/archimatetool/editor/diagram/actions/CopySnapshot.java
@@ -583,12 +583,22 @@ public final class CopySnapshot {
         }
         
         // Insert references into the map from the snapshot to the pasted / existing elements.
-        snapshotToNewObjectsMapping.put(snapshotObject, objectReferences);        
+        // However, if there already are references from snapshotObject, merge them into the reference set, to allow the set to 
+        // be "complete", and not only the last visited child in a given nested set.
+        // TODO: I have no tests for this, currently.
+        if (snapshotToNewObjectsMapping.containsKey(snapshotObject)) {
+        	List<IDiagramModelObject> existing = snapshotToNewObjectsMapping.get(snapshotObject);
+        	for (IDiagramModelObject object : objectReferences) {
+        		if (!existing.contains(object)) {
+        			existing.add(object);
+        		}
+        	}
+        } else {
+            snapshotToNewObjectsMapping.put(snapshotObject, objectReferences);        
+        }
         
         // If container, recurse
         // TODO: REALLY, really have to think about what happens here.
-        // If snapshotObject is a container, it probably have children.
-        // For each of these children, create a mergecommand, with all the references for snapshopObject...
         
         
         // FINAL UPDATE BEFORE VACATION: 

--- a/com.archimatetool.editor/src/com/archimatetool/editor/diagram/actions/CutAction.java
+++ b/com.archimatetool.editor/src/com/archimatetool/editor/diagram/actions/CutAction.java
@@ -27,8 +27,8 @@ import com.archimatetool.model.IDiagramModelObject;
  */
 public class CutAction extends CopyAction {
     
-    public CutAction(IWorkbenchPart part, PasteAction pasteAction) {
-        super(part, pasteAction);
+    public CutAction(IWorkbenchPart part, PasteAction pasteAction, MergeAction mergeAction) {
+        super(part, pasteAction, mergeAction);
     }
     
     @Override

--- a/com.archimatetool.editor/src/com/archimatetool/editor/diagram/actions/MergeAction.java
+++ b/com.archimatetool.editor/src/com/archimatetool/editor/diagram/actions/MergeAction.java
@@ -1,0 +1,45 @@
+package com.archimatetool.editor.diagram.actions;
+
+import org.eclipse.gef.GraphicalViewer;
+import org.eclipse.gef.ui.actions.Clipboard;
+import org.eclipse.ui.ISharedImages;
+import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.PlatformUI;
+/**
+ * Merge Action
+ * 
+ * This is almost identical to a paste, except it merges the selection into the current diagram, by issuing a MergeCommand.
+ * 
+ * @author Mads Bondo Dydensborg
+ */
+public class MergeAction extends PasteAction {
+
+	public static final String ID = "MergeAction"; //$NON-NLS-1$
+    public static final String TEXT = Messages.MergeAction_0;
+	
+	public MergeAction(IWorkbenchPart part, GraphicalViewer viewer) {
+		super(part, viewer);
+        setText(TEXT);
+        setId(ID);
+        // TODO: Could be changed to something else than "Paste", if supported.
+        ISharedImages sharedImages = PlatformUI.getWorkbench().getSharedImages();
+        setImageDescriptor(sharedImages.getImageDescriptor(ISharedImages.IMG_TOOL_PASTE));
+        setDisabledImageDescriptor(sharedImages.getImageDescriptor(ISharedImages.IMG_TOOL_PASTE_DISABLED));
+        setEnabled(false);
+	}
+	
+	// Almost identical to Paste, except it uses a merge command.
+	@Override
+	public void run() {
+		Object obj = Clipboard.getDefault().getContents();
+        
+        if(obj instanceof CopySnapshot) {
+            CopySnapshot clipBoardCopy = (CopySnapshot)obj;
+            execute(clipBoardCopy.getMergeCommand(getTargetDiagramModel(), fGraphicalViewer, fMousePosition));
+            fMousePosition = null;
+        }
+  
+	}
+	
+
+}

--- a/com.archimatetool.editor/src/com/archimatetool/editor/diagram/actions/Messages.java
+++ b/com.archimatetool.editor/src/com/archimatetool/editor/diagram/actions/Messages.java
@@ -180,6 +180,8 @@ public class Messages extends NLS {
     public static String ToggleSnapToAlignmentGuidesAction_0;
 
     public static String ViewpointAction_0;
+
+	public static String MergeAction_0;
     static {
         // initialize resource bundle
         NLS.initializeMessages(BUNDLE_NAME, Messages.class);

--- a/com.archimatetool.editor/src/com/archimatetool/editor/diagram/actions/PasteAction.java
+++ b/com.archimatetool.editor/src/com/archimatetool/editor/diagram/actions/PasteAction.java
@@ -31,9 +31,9 @@ import com.archimatetool.model.IDiagramModel;
  */
 public class PasteAction extends SelectionAction {
     
-    private GraphicalViewer fGraphicalViewer;
+    protected GraphicalViewer fGraphicalViewer;
     
-    private Point fMousePosition = null;
+    protected Point fMousePosition = null;
     
     private IWindowListener windowListener = new IWindowListener() {
         public final void windowActivated(IWorkbenchWindow window) {
@@ -109,9 +109,7 @@ public class PasteAction extends SelectionAction {
         
         if(obj instanceof CopySnapshot) {
             CopySnapshot clipBoardCopy = (CopySnapshot)obj;
-            // TODO: MUST CHANGE THIS, THIS IS JUST TESTING!
-            // execute(clipBoardCopy.getPasteCommand(getTargetDiagramModel(), fGraphicalViewer, fMousePosition));
-            execute(clipBoardCopy.getMergeCommand(getTargetDiagramModel(), fGraphicalViewer, fMousePosition));
+            execute(clipBoardCopy.getPasteCommand(getTargetDiagramModel(), fGraphicalViewer, fMousePosition));
             fMousePosition = null;
         }
     }
@@ -121,7 +119,7 @@ public class PasteAction extends SelectionAction {
         fMousePosition = null;
     }
     
-    private IDiagramModel getTargetDiagramModel() {
+    protected IDiagramModel getTargetDiagramModel() {
         IDiagramModel diagramModel = (IDiagramModel)getWorkbenchPart().getAdapter(IDiagramModel.class);
         if(diagramModel == null) {
             System.err.println("DiagramModel was null in " + getClass()); //$NON-NLS-1$

--- a/com.archimatetool.editor/src/com/archimatetool/editor/diagram/actions/PasteAction.java
+++ b/com.archimatetool.editor/src/com/archimatetool/editor/diagram/actions/PasteAction.java
@@ -109,7 +109,9 @@ public class PasteAction extends SelectionAction {
         
         if(obj instanceof CopySnapshot) {
             CopySnapshot clipBoardCopy = (CopySnapshot)obj;
-            execute(clipBoardCopy.getPasteCommand(getTargetDiagramModel(), fGraphicalViewer, fMousePosition));
+            // TODO: MUST CHANGE THIS, THIS IS JUST TESTING!
+            // execute(clipBoardCopy.getPasteCommand(getTargetDiagramModel(), fGraphicalViewer, fMousePosition));
+            execute(clipBoardCopy.getMergeCommand(getTargetDiagramModel(), fGraphicalViewer, fMousePosition));
             fMousePosition = null;
         }
     }

--- a/com.archimatetool.editor/src/com/archimatetool/editor/diagram/actions/messages.properties
+++ b/com.archimatetool.editor/src/com/archimatetool/editor/diagram/actions/messages.properties
@@ -66,6 +66,8 @@ LockObjectAction_0=Lock
 LockObjectAction_1=Lock the component
 LockObjectAction_2=Unlock
 
+MergeAction_0=&Merge
+
 PasteAction_0=&Paste
 
 PrintModeDialog_0=Print

--- a/tests/com.archimatetool.editor.tests/src/com/archimatetool/editor/diagram/actions/CopySnapshotTests.java
+++ b/tests/com.archimatetool.editor.tests/src/com/archimatetool/editor/diagram/actions/CopySnapshotTests.java
@@ -13,13 +13,18 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
 import junit.framework.JUnit4TestAdapter;
 
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.gef.GraphicalViewer;
 import org.eclipse.gef.commands.Command;
+import org.eclipse.ui.internal.Model;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,15 +32,21 @@ import org.junit.Test;
 import com.archimatetool.editor.ArchimateTestModel;
 import com.archimatetool.editor.TestSupport;
 import com.archimatetool.editor.diagram.actions.CopySnapshot.BidiHashtable;
+import com.archimatetool.editor.diagram.commands.DiagramCommandFactory;
+import com.archimatetool.editor.model.commands.DeleteElementCommand;
 import com.archimatetool.model.IArchimateDiagramModel;
+import com.archimatetool.model.IArchimateElement;
 import com.archimatetool.model.IArchimateFactory;
 import com.archimatetool.model.IArchimateModel;
 import com.archimatetool.model.IDiagramModel;
 import com.archimatetool.model.IDiagramModelArchimateConnection;
 import com.archimatetool.model.IDiagramModelArchimateObject;
+import com.archimatetool.model.IDiagramModelConnection;
 import com.archimatetool.model.IDiagramModelContainer;
+import com.archimatetool.model.IDiagramModelGroup;
 import com.archimatetool.model.IDiagramModelObject;
 import com.archimatetool.model.IDiagramModelReference;
+import com.archimatetool.model.INameable;
 import com.archimatetool.model.IRelationship;
 
 @SuppressWarnings("nls")
@@ -54,6 +65,7 @@ public class CopySnapshotTests {
     public void runOnceBeforeEachTest() throws IOException {
         tm = new ArchimateTestModel(TestSupport.TEST_MODEL_FILE_ARCHISURANCE);
         model = tm.loadModelWithCommandStack();
+        // Note: the source diagram model used, is the view "Layered View" from the ArchiShurance test mode.
         sourceDiagramModel = model.getDiagramModels().get(1);
         targetDiagramModel = tm.addNewArchimateDiagramModel();
     }
@@ -96,6 +108,8 @@ public class CopySnapshotTests {
         assertFalse(snapshot.canPasteToDiagram(sketchModel));
     }
         
+    
+    
     @Test
     public void testCanPasteToDiagram_DifferentModelDiagramReference() {
         // Test can't paste IDiagramModelReference to another Archimate model
@@ -146,6 +160,250 @@ public class CopySnapshotTests {
         // Same number of connections pasted
         assertEquals(countConnections(selectedObjects), countConnections(targetDiagramModel.getChildren()));
     }
+
+
+    
+    // mbd: 2014-04-12
+    // This test is because I need something to support refactoring the method  on CopySnapShot.
+    // Unfortunately, the method "needsCopiedArchimateElements" is private.
+    // In lack of knowledge of policy, I use reflection to get the private method. I know some people dislike this. 
+    @Test
+    public void testNeedsCopiedArchimateElements() {
+    	// Reflection helper class. Construct, then use call to call.
+    	// The call emulates the part of getPasteCommand that sets up a field on the CopySnapshot instance.
+    	class NCAECaller {
+    		Method method;
+    		Field field;
+    		CopySnapshot snapshot;
+        	NCAECaller(CopySnapshot snapshot) {
+                @SuppressWarnings("rawtypes")
+				Class[] argClasses = {IDiagramModel.class};
+        		try {
+        			method = CopySnapshot.class.getDeclaredMethod("needsCopiedArchimateElements", argClasses);
+        		} catch (NoSuchMethodException | SecurityException e) {
+        			throw new AssertionError("Unable to access private method CopySnapshot.needsCopiedArchimateElements during test", e);
+        		}
+                method.setAccessible(true); 
+                try {
+                	field = CopySnapshot.class.getDeclaredField("fTargetArchimateModel");
+				} catch (NoSuchFieldException | SecurityException e) {
+					throw new AssertionError("Unable to access private field CopySnapshot.fTargetArchimateModel during test", e);
+				}	
+                field.setAccessible(true);
+                this.snapshot = snapshot;
+        	};
+        	boolean needsCopiedArchimateElements(IDiagramModel diagramModel) {
+                Object[] argObjects = {diagramModel};
+                // Since the selection contains stuff, and the target does not, it should be OK.
+                try {
+                	// As part of the public getPasteCommand, fTargetArchimateModel is set, so we set it here
+                	field.set(snapshot, diagramModel.getArchimateModel());
+                	return (boolean) method.invoke(snapshot, argObjects);
+				} catch (IllegalAccessException | IllegalArgumentException
+						| InvocationTargetException e) {
+        			throw new AssertionError("Call to private method CopySnapshot.needsCopiedArchimateElements failed during test", e);
+				}
+        	}
+        };
+
+        // Check some assumptions about the model before trying to test on it.
+        assertEquals("sourceDiagramModel does not point at Layered View, or it changed name", "Layered View", sourceDiagramModel.getName() );
+        assertEquals("number of elements on view have changed", 7, sourceDiagramModel.getChildren().size());
+
+        // TODO: Note, technically, a test is missing with a partial overlap of elements; that is, the selection contains a single element already present in the target diagram.
+        
+        // No need to copy, if objects taken from source view, and copied to new empty diagram (in the same archimate model)
+        {
+            // Set up a selection with objects from the source diagram model.
+        	List<IDiagramModelObject> selectedObjects = new ArrayList<IDiagramModelObject>();
+            selectedObjects.addAll(sourceDiagramModel.getChildren());
+            
+            // Create a snapshot based on the objects in the selection.
+            CopySnapshot snapshot = new CopySnapshot(selectedObjects);
+            assertNotNull(snapshot);
+
+            // Set up helper for the reflection stuff.
+            NCAECaller caller = new NCAECaller(snapshot);
+            assertFalse("No need to copy selection, when copying to emty diagram", caller.needsCopiedArchimateElements(targetDiagramModel));
+        }
+
+        // Same test as above, but using a single element from another diagram and paste it into target diagram => no copy needed
+        {
+        	// Find a single element from the source and copy it into the view
+        	// 4193 is a firewall element in a diagram different from the Layered View.
+        	 EObject element = tm.getObjectByID("4193");
+             assertNotNull(element);
+             assertTrue( "This must be a diagram element", element instanceof IDiagramModelObject );
+        	
+             // Set up a selection with objects from the source diagram model.
+             List<IDiagramModelObject> selectedObjects = new ArrayList<IDiagramModelObject>();
+             selectedObjects.add((IDiagramModelObject) element);
+             
+             // Create a snapshot based on the objects in the selection.
+             CopySnapshot snapshot = new CopySnapshot(selectedObjects);
+             assertNotNull(snapshot);
+
+             // Set up helper for the reflection stuff.
+             NCAECaller caller = new NCAECaller(snapshot);
+             assertFalse("No need to copy element, if element not present in target diagram", caller.needsCopiedArchimateElements(targetDiagramModel));
+        }
+                
+        // Must copy, if an element has been deleted
+        {
+        	// Find a single element from the source and copy it into the view
+        	// 4193 is a firewall element in a diagram different from the Layered View.
+        	 EObject element = tm.getObjectByID("4193");
+             assertNotNull(element);
+             assertTrue( "This must be a diagram object", element instanceof IDiagramModelObject );
+             assertTrue( "This must be an archimate diagram element", element instanceof IDiagramModelArchimateObject );
+             
+             IDiagramModelArchimateObject object = (IDiagramModelArchimateObject) element;
+             assertTrue( "The underlying archimate element must be an INameable", object.getArchimateElement() instanceof INameable);
+             
+             // Set up a selection with objects from the source diagram model.
+             List<IDiagramModelObject> selectedObjects = new ArrayList<IDiagramModelObject>();
+             selectedObjects.add(object);
+             
+             // Create a snapshot based on the objects in the selection.
+             CopySnapshot snapshot = new CopySnapshot(selectedObjects);
+             assertNotNull(snapshot);
+
+             // Delete the element from the diagram it came from. I hope.
+             // TODO: I hope this does what I think it does... it probably leaves an inconsistent model
+             // I had a look at the DeleteFromModelAction but it needed an IWorkbenchPart, and I really don't think I have one with me.
+             Command cmd = new DeleteElementCommand(object.getArchimateElement());
+             cmd.execute();
+             object.setArchimateElement(null);
+             assertTrue( "The archimate element should now be deleted", null == object.getArchimateElement());
+
+             // Set up helper for the reflection stuff.
+             NCAECaller caller = new NCAECaller(snapshot);
+             // Since the selection contains an element that have been deleted from the mode, a copy is needed
+             assertTrue("Must copy element, when element has been deleted in the model", caller.needsCopiedArchimateElements(targetDiagramModel));
+
+             // Restore the model as it was.
+             tm = new ArchimateTestModel(TestSupport.TEST_MODEL_FILE_ARCHISURANCE);
+             try {
+				model = tm.loadModelWithCommandStack();
+			} catch (IOException e) {
+				throw new AssertionError( "Unable to reload/reset the model file while testing", e);
+			}
+             // Note: the source model used, is the view "Layered View" from the ArchiShurance test mode.
+             sourceDiagramModel = model.getDiagramModels().get(1);
+             targetDiagramModel = tm.addNewArchimateDiagramModel();
+        }
+
+        // Must copy, if an element is present in target; copy from the model into it self
+        {
+        	// Find a single element from the source and copy it into the view
+        	// 4104 is an element from the layered view.
+        	 EObject element = tm.getObjectByID("4104");
+             assertNotNull(element);
+             assertTrue( "This must be a diagram element", element instanceof IDiagramModelObject );
+             
+             // Set up a selection with objects from the source diagram model.
+             List<IDiagramModelObject> selectedObjects = new ArrayList<IDiagramModelObject>();
+             selectedObjects.add((IDiagramModelObject) element);
+             
+             // Create a snapshot based on the objects in the selection.
+             CopySnapshot snapshot = new CopySnapshot(selectedObjects);
+             assertNotNull(snapshot);
+
+             // Set up helper for the reflection stuff.
+             NCAECaller caller = new NCAECaller(snapshot);
+             assertTrue("Must copy if element present in diagram already", caller.needsCopiedArchimateElements(sourceDiagramModel));
+        }
+
+        // Must copy, if an relationship has been deleted
+        {
+            // Set up a selection with objects from the source diagram model.
+        	List<IDiagramModelObject> selectedObjects = new ArrayList<IDiagramModelObject>();
+            selectedObjects.addAll(sourceDiagramModel.getChildren());
+            
+            // Create a snapshot based on the objects in the selection.
+            CopySnapshot snapshot = new CopySnapshot(selectedObjects);
+            assertNotNull(snapshot);
+        	
+        	// Find a single relation from the source and delete it
+        	// 4153 is a connection from the Layered View, that uses the relation in 1446 
+        	 EObject element = tm.getObjectByID("4153");
+             assertNotNull(element);
+             assertTrue( "This must be a diagram object", element instanceof IDiagramModelConnection );
+             assertTrue( "This must be an archimate diagram connection", element instanceof IDiagramModelArchimateConnection );
+             
+             IDiagramModelArchimateConnection connection = (IDiagramModelArchimateConnection) element;
+
+             // TODO: This is probably not the way to delete the relation from the model
+             assertTrue( "The underlying archimate connection must be an INameable", connection.getRelationship() instanceof INameable);
+             assertEquals( "Got the right connection", "1446", connection.getRelationship().getId() );
+             Command cmd = new DeleteElementCommand(connection.getRelationship());
+             cmd.execute();
+             connection.setRelationship(null);             
+            
+             // Set up helper for the reflection stuff.
+             NCAECaller caller = new NCAECaller(snapshot);
+             assertTrue("Must copy when connection has been deleted", caller.needsCopiedArchimateElements(targetDiagramModel));
+
+             // Restore the model as it was.
+             tm = new ArchimateTestModel(TestSupport.TEST_MODEL_FILE_ARCHISURANCE);
+             try {
+				model = tm.loadModelWithCommandStack();
+			} catch (IOException e) {
+				throw new AssertionError( "Unable to reload/reset the model file while testing", e);
+			}
+             // Note: the source model used, is the view "Layered View" from the ArchiShurance test mode.
+             sourceDiagramModel = model.getDiagramModels().get(1);
+             targetDiagramModel = tm.addNewArchimateDiagramModel();
+        }
+
+        // TODO: Must copy if an relationship is already present in target
+        {
+        	// I don't know how to write this test...
+        }
+
+        
+    	// Must copy if same model, and it contains elements already present.
+        // This is a copy of everything, so it should return true
+        {
+            // Set up a selection with objects from the source model.
+        	List<IDiagramModelObject> selectedObjects = new ArrayList<IDiagramModelObject>();
+            selectedObjects.addAll(sourceDiagramModel.getChildren());
+            
+            // Create a snapshot based on the objects in the selection.
+            CopySnapshot snapshot = new CopySnapshot(selectedObjects);
+            assertNotNull(snapshot);
+
+            // Set up helper for the reflection stuff.
+            NCAECaller caller = new NCAECaller(snapshot);
+            assertTrue("Must copy if selection contains elements already present", (boolean) caller.needsCopiedArchimateElements(sourceDiagramModel));
+        }
+
+        // Must return copy if different ArchimateModesl....
+        {
+            // Load a new ArchimateTestModel
+        	ArchimateTestModel tm2 = new ArchimateTestModel(TestSupport.TEST_MODEL_FILE_ARCHISURANCE);
+        	IArchimateModel model2;
+            try {
+				 model2 = tm2.loadModelWithCommandStack();
+			} catch (IOException e) {
+				throw new AssertionError( "Unable to load an additional model file while testing", e);
+			}
+            targetDiagramModel = tm2.addNewArchimateDiagramModel();
+            
+            // Set up a selection with objects from the source model.
+        	List<IDiagramModelObject> selectedObjects = new ArrayList<IDiagramModelObject>();
+            selectedObjects.addAll(sourceDiagramModel.getChildren());
+            
+            // Create a snapshot based on the objects in the selection.
+            CopySnapshot snapshot = new CopySnapshot(selectedObjects);
+            assertNotNull(snapshot);
+
+            // Set up helper for the reflection stuff.
+            NCAECaller caller = new NCAECaller(snapshot);
+            assertTrue("Must copy if archimate models are different", caller.needsCopiedArchimateElements(targetDiagramModel));
+        }
+    }
+
     
     @Test
     public void testNestedConnectionIsCopied() {


### PR DESCRIPTION
This is *not* a pull request at this moment.

This is more of a "please comment/review". (If reception in genereal is favorable, I will clean the code up, create docs, suitable tests, (icons?) etc, for a "proper" pull request.). It is related to feature request https://github.com/Phillipus/archi/issues/60

What this branch/request does: It puts a new version of "paste" on the diagram contexts menus, called "merge". Merge works like this: for each element in the selection, it tries to figure out if the associated archimate element is already present in the diagram beeing pasted into. If it is, this will be used as a reference instead of pasting a new element. The usecase is "updates" and the like, where a diagram (view) for e.g. a host gets updated with e.g. a new infrastructure service or the like, and you want this change to be reflected in other views where the diagram is used. Another usecase is when you want to combine the elements from two or more views into one.

For my use, it works quite well, but there is some loose ends regarding the merging of duplacates, especially duplicate containers and/or groups. This is mostly some choice about what makes most sense: Currently duplicate elements in the selection are beeing silently merged, whereas relations between duplicate elements in the target gets "exploded" (all permuations).

There is some discussion of the approach on this wiki page: https://github.com/Phillipus/archi/wiki/Selecting,-Copying,-Duplicating-and-Merging .

The code is mostly additions to CopySnapshot, and the needed "glue" to get a new Merge entry. Because I needed to understand the code, there is quite a lot of unittests added to needsCopiedArchimateElements - which I ended up not using, btw - which may go in a final pull request. I also added a lot of JSDOC comments - I obviously hope they are relevant/useful, although I know I do tend to overcomment code.