### PR TITLE
Adds (hidden) caption/title for full screen window.

### DIFF
--- a/com.archimatetool.editor/src/com/archimatetool/editor/diagram/actions/FullScreenAction.java
+++ b/com.archimatetool.editor/src/com/archimatetool/editor/diagram/actions/FullScreenAction.java
@@ -176,6 +176,7 @@ public class FullScreenAction extends WorkbenchPartAction {
         // SWT.SHELL_TRIM is needed for GTK for a full-size shell (tested on Ubuntu)
         int style = PlatformUtils.isWindows() ? SWT.APPLICATION_MODAL : SWT.APPLICATION_MODAL | SWT.SHELL_TRIM ;
         fNewShell = new Shell(Display.getCurrent(), style); 
+        fNewShell.setText("ArchiFullScreen"); //$NON-NLS-1$
         fNewShell.setFullScreen(true);
         fNewShell.setMaximized(true);
         fNewShell.setLayout(new FillLayout());


### PR DESCRIPTION
 Makes it easier to handle in Linux. Untested in Mac/Windows.

There are some window operations in Linux that are somewhat easier to perform with a window that has a name; this includes controlling wheter a full screen window will span multiple screens or not. Please consider this for inclusing.
