### PR TITLE
Allow override of default browser type for hints window

### DIFF
--- a/com.archimatetool.help/src/com/archimatetool/help/hints/HintsView.java
+++ b/com.archimatetool.help/src/com/archimatetool/help/hints/HintsView.java
@@ -187,8 +187,8 @@ implements IContextProvider, IHintsView, ISelectionListener, IComponentSelection
     private Browser createBrowser(Composite parent) {
         Browser browser = null;
         try {
-            // On Eclipse 3.6 set this
-            if(PlatformUtils.isGTK()) {
+            // On Eclipse 3.6 set this, but check that user did not try to override for e.g. later versions.
+            if(PlatformUtils.isGTK() && System.getProperty("org.eclipse.swt.browser.DefaultType") == null) { //$NON-NLS-1$ 
                 System.setProperty("org.eclipse.swt.browser.UseWebKitGTK", "true"); //$NON-NLS-1$ //$NON-NLS-2$
             }
             browser = new Browser(parent, SWT.NONE);

--- a/com.archimatetool.help/src/com/archimatetool/help/hints/messages.properties
+++ b/com.archimatetool.help/src/com/archimatetool/help/hints/messages.properties
@@ -1,6 +1,6 @@
 HintsView_0=Pin to selection
 HintsView_1=Pins the content to the current selection
 HintsView_2=Hints View Error
-HintsView_3=Cannot create Browser component.\nIf you are running on Linux, try installing libwebkit-1.0-0.
+HintsView_3=Cannot create Browser component.\nIf you are running on Linux, try using -Dorg.eclipse.swt.browser.DefaultType=mozilla or -Dorg.eclipse.swt.browser.DefaultType=webkit in Archi32.ini or Archi64.ini. 
 HintsView_4=Hints Window
 IHintsView_0=Hints


### PR DESCRIPTION
Linux users will experience that newer versions of libwebkitgtk will not work with Archi (see https://github.com/Phillipus/archi/wiki/Archi-crashes-under-Linux,-with-a-reference-to-libwebkit-WebKitGtk). The current code for the Hints window, forces GTK platforms (most Linux users, I guess?) to use libwebkit for browser widgets. This patch _should_ allow overrides, which Eclipse honours from version 3.7 forward (https://www.eclipse.org/swt/faq.php#browserspecifydefault).

I write _should_ because I have been unable to confirm this, as I can't figure out how to pass -D arguments to the eclipse run configurations, but the code should be right, and it still works for me... ;-)
