### PR TITLE
[junction-anchor-fix] fix orthogonal anchor issue for junctions (part 1)

### DIFF
--- a/com.archimatetool.editor/src/com/archimatetool/editor/diagram/editparts/OrthogonalAnchor.java
+++ b/com.archimatetool.editor/src/com/archimatetool/editor/diagram/editparts/OrthogonalAnchor.java
@@ -45,6 +45,9 @@ import com.archimatetool.editor.diagram.figures.IRoundedRectangleFigure;
 import com.archimatetool.editor.diagram.figures.RoundedRectangleFigureDelegate;
 import com.archimatetool.editor.diagram.figures.business.BusinessInterfaceFigure;
 import com.archimatetool.editor.diagram.figures.business.BusinessValueFigure;
+import com.archimatetool.editor.diagram.figures.junctions.AndJunctionFigure;
+import com.archimatetool.editor.diagram.figures.junctions.JunctionFigure;
+import com.archimatetool.editor.diagram.figures.junctions.OrJunctionFigure;
 
 
 /**
@@ -390,6 +393,11 @@ public class OrthogonalAnchor extends ChopboxAnchor {
         	// ellipse case
             if (((BusinessInterfaceFigure)figure).getDiagramModelObject().getType() != 0)
             	corner = figure.getSize();
+        } else if (figure instanceof JunctionFigure
+		  || figure instanceof OrJunctionFigure
+		  || figure instanceof AndJunctionFigure) {
+        	// junction case
+        	corner = figure.getSize();
         }
 		
 		return corner;

--- a/com.archimatetool.editor/src/com/archimatetool/editor/diagram/editparts/junctions/JunctionEditPart.java
+++ b/com.archimatetool.editor/src/com/archimatetool/editor/diagram/editparts/junctions/JunctionEditPart.java
@@ -8,7 +8,6 @@ package com.archimatetool.editor.diagram.editparts.junctions;
 import org.eclipse.draw2d.ConnectionAnchor;
 import org.eclipse.draw2d.EllipseAnchor;
 import org.eclipse.draw2d.IFigure;
-import org.eclipse.gef.ConnectionEditPart;
 import org.eclipse.gef.EditPolicy;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.RequestConstants;
@@ -32,26 +31,6 @@ implements INonResizableEditPart {
     @Override
     protected IFigure createFigure() {
         return new JunctionFigure(getModel());
-    }
-    
-    @Override
-    public ConnectionAnchor getSourceConnectionAnchor(ConnectionEditPart connection) {
-        return getDefaultConnectionAnchor();
-    }
-    
-    @Override
-    public ConnectionAnchor getSourceConnectionAnchor(Request request) {
-        return getDefaultConnectionAnchor();
-    }
-    
-    @Override
-    public ConnectionAnchor getTargetConnectionAnchor(ConnectionEditPart connection) {
-        return getDefaultConnectionAnchor();
-    }
-    
-    @Override
-    public ConnectionAnchor getTargetConnectionAnchor(Request request) {
-        return getDefaultConnectionAnchor();
     }
 
     @Override


### PR DESCRIPTION
This fix cancels your commit and fixes the issue: with it the arrow always touch the junction's figure.