### PR TITLE
[Jasper Report]  Report generated date style

### DIFF
--- a/com.archimatetool.jasperreports/reports/Customizable Report/main.jrxml
+++ b/com.archimatetool.jasperreports/reports/Customizable Report/main.jrxml
@@ -108,7 +108,7 @@
 				<textFieldExpression><![CDATA[$V{REPORT_TITLE}]]></textFieldExpression>
 			</textField>
 			<textField>
-				<reportElement positionType="Float" x="1" y="349" width="515" height="20" uuid="0d3ecbc2-8dbe-4a48-a461-34c06224f5a4"/>
+				<reportElement style="Title Date" positionType="Float" x="1" y="349" width="515" height="20" uuid="0d3ecbc2-8dbe-4a48-a461-34c06224f5a4"/>
 				<textFieldExpression><![CDATA[$P{DATE_NOW}]]></textFieldExpression>
 			</textField>
 			<break>

--- a/com.archimatetool.jasperreports/reports/Customizable Report/style.jrtx
+++ b/com.archimatetool.jasperreports/reports/Customizable Report/style.jrtx
@@ -5,6 +5,7 @@
 	<style name="Normal" fontName="DejaVu Sans" fontSize="12"/>
 	<style name="Bold" style="Normal" isBold="true"/>
 	<style name="Title" style="Normal" fontSize="22"/>
+	<style name="Title Date" style="Normal" fontSize="10"/>
 	<style name="Page footer" style="Normal" forecolor="#666666" fontSize="8"/>
 	<style name="Title 1" style="Normal" forecolor="#7CA9BF" fontSize="20"/>
 	<style name="Title 2" style="Normal" forecolor="#7CA9BF" fontSize="16"/>


### PR DESCRIPTION
When Jasper Report is exported to PDF with Russian locale the report generated date is missing the month and looks like `31 2017 22:02:34` instead of `31 июл 2017 22:02:34`. Looks like this is know Jasper report export to PDF font issue. So I've added new style derived from `Normal` called `Title Date`, so this element also exported using `Dejavu Sans` font. This patch solves the issue. Probably this could solve the same issue not only for Russian, but for any cyrillic languages, may be some others too.