### PR TITLE
[Feature Request] / [Bug] : Improve Link to Editor Function with view

### DIFF
--- a/com.archimatetool.editor/src/com/archimatetool/editor/diagram/ArchimateDiagramEditor.java
+++ b/com.archimatetool.editor/src/com/archimatetool/editor/diagram/ArchimateDiagramEditor.java
@@ -36,6 +36,7 @@ import com.archimatetool.editor.ui.findreplace.IFindReplaceProvider;
 import com.archimatetool.model.IArchimateConcept;
 import com.archimatetool.model.IArchimateDiagramModel;
 import com.archimatetool.model.IArchimatePackage;
+import com.archimatetool.model.IDiagramModel;
 import com.archimatetool.model.IDiagramModelComponent;
 import com.archimatetool.model.viewpoints.IViewpoint;
 import com.archimatetool.model.viewpoints.ViewpointManager;
@@ -159,7 +160,20 @@ implements IArchimateDiagramEditor {
         viewer.setContextMenu(provider);
         getSite().registerContextMenu(ArchimateDiagramEditorContextMenuProvider.ID, provider, viewer);
     }
-    
+    @Override
+    public void selectDiagramObject(IDiagramModel[] diagramModels) {
+    	List<Object> objects = new ArrayList<>();
+    	
+    	for(IDiagramModel diagramModel : diagramModels) {
+    		// Find Diagram Reference 
+    		for(IDiagramModelComponent dc : DiagramModelUtils.findDiagramModelReferences(getModel(), diagramModel)) {
+    			if(!objects.contains(dc)) {
+    				objects.add(dc);
+    			}
+    		}
+    	}
+    	selectObjects(objects.toArray());
+    }
     @Override
     public void selectArchimateConcepts(IArchimateConcept[] archimateConcepts) {
         List<Object> objects = new ArrayList<Object>();

--- a/com.archimatetool.editor/src/com/archimatetool/editor/diagram/IArchimateDiagramEditor.java
+++ b/com.archimatetool.editor/src/com/archimatetool/editor/diagram/IArchimateDiagramEditor.java
@@ -6,6 +6,8 @@
 package com.archimatetool.editor.diagram;
 
 import com.archimatetool.model.IArchimateConcept;
+import com.archimatetool.model.IArchimateDiagramModel;
+import com.archimatetool.model.IDiagramModel;
 
 
 /**
@@ -23,4 +25,10 @@ public interface IArchimateDiagramEditor extends IDiagramModelEditor {
      * @param archimateConcepts
      */
     void selectArchimateConcepts(IArchimateConcept[] archimateConcepts);
+    
+    /**
+     * Select the graphical objects wrapping Diagrams (Archimate, Sketch, Canvas, ...)
+     * @param archimateDiagrams
+     */
+    void selectDiagramObject(IDiagramModel[] diagramModels);
 }

--- a/com.archimatetool.editor/src/com/archimatetool/editor/diagram/IArchimateDiagramEditor.java
+++ b/com.archimatetool.editor/src/com/archimatetool/editor/diagram/IArchimateDiagramEditor.java
@@ -6,7 +6,6 @@
 package com.archimatetool.editor.diagram;
 
 import com.archimatetool.model.IArchimateConcept;
-import com.archimatetool.model.IArchimateDiagramModel;
 import com.archimatetool.model.IDiagramModel;
 
 

--- a/com.archimatetool.editor/src/com/archimatetool/editor/views/tree/TreeSelectionSynchroniser.java
+++ b/com.archimatetool.editor/src/com/archimatetool/editor/views/tree/TreeSelectionSynchroniser.java
@@ -28,8 +28,10 @@ import com.archimatetool.editor.diagram.IDiagramModelEditor;
 import com.archimatetool.editor.preferences.Preferences;
 import com.archimatetool.editor.ui.components.PartListenerAdapter;
 import com.archimatetool.model.IArchimateConcept;
+import com.archimatetool.model.IArchimateDiagramModel;
 import com.archimatetool.model.IDiagramModel;
 import com.archimatetool.model.IDiagramModelArchimateComponent;
+import com.archimatetool.model.IDiagramModelReference;
 
 
 
@@ -146,6 +148,12 @@ public class TreeSelectionSynchroniser implements ISelectionChangedListener {
                         model = ((IDiagramModelArchimateComponent)model).getArchimateConcept();
                         selected.add(model);
                     }
+                    // If the selected object is a reference to a diagram model
+                    else if (model instanceof IDiagramModelReference) {
+                    	// TODO: Clarify it's getReferenceModel. But Why ???
+                    	//selected.add(((IDiagramModelReference) model).getDiagramModel());
+                    	selected.add(((IDiagramModelReference)model).getReferencedModel());
+                    }
                     // Diagram model
                     else if(model instanceof IDiagramModel) {
                         selected.add(model);
@@ -158,18 +166,23 @@ public class TreeSelectionSynchroniser implements ISelectionChangedListener {
         }
         // Selection from Tree, so select objects in any open Archimate Diagram Editors
         else if(source instanceof TreeViewer) {
-            List<IArchimateConcept> selected = new ArrayList<IArchimateConcept>();
+            List<IArchimateConcept> selectedConcept = new ArrayList<IArchimateConcept>();
+            List<IDiagramModel> selectedDiagModel = new ArrayList<>();
             
             // Archimate concepts
             for(Object o : ((IStructuredSelection)selection).toArray()) {
                 if(o instanceof IArchimateConcept) {
-                    selected.add((IArchimateConcept)o);
+                	selectedConcept.add((IArchimateConcept)o);
+                }
+                else if(o instanceof IDiagramModel) {
+                	selectedDiagModel.add((IDiagramModel)o);
                 }
             }
             
             // Select these (or an empty selection) in the Diagram Editors
             for(IArchimateDiagramEditor editor : getOpenEditors()) {
-                editor.selectArchimateConcepts(selected.toArray(new IArchimateConcept[selected.size()]));
+                editor.selectArchimateConcepts(selectedConcept.toArray(new IArchimateConcept[selectedConcept.size()]));
+                editor.selectDiagramObject(selectedDiagModel.toArray(new IDiagramModel[selectedDiagModel.size()]));
             }
         }
         

--- a/com.archimatetool.editor/src/com/archimatetool/editor/views/tree/TreeSelectionSynchroniser.java
+++ b/com.archimatetool.editor/src/com/archimatetool/editor/views/tree/TreeSelectionSynchroniser.java
@@ -28,7 +28,6 @@ import com.archimatetool.editor.diagram.IDiagramModelEditor;
 import com.archimatetool.editor.preferences.Preferences;
 import com.archimatetool.editor.ui.components.PartListenerAdapter;
 import com.archimatetool.model.IArchimateConcept;
-import com.archimatetool.model.IArchimateDiagramModel;
 import com.archimatetool.model.IDiagramModel;
 import com.archimatetool.model.IDiagramModelArchimateComponent;
 import com.archimatetool.model.IDiagramModelReference;


### PR DESCRIPTION
Currently the Link to Editor is working quite fine with all archimate concept.
There is an enhancement : if you click inside your view, the link will select the very same view in the model tree.

However, I needed a bit more, which I share here : 
When you add Views inside a Diagram (for instance for a 'Welcome' View), you don't have any sync. between the Model and the View inside your diagram. 
This is the meaning of this Pull Request
<img width="453" alt="view" src="https://user-images.githubusercontent.com/43959255/58428674-802d7c80-80a3-11e9-98c7-bbae1b1d2e28.png">
