### PR TITLE
feat: markdown parsing

### DIFF
--- a/com.archimatetool.reports/templates/html/js/frame.js
+++ b/com.archimatetool.reports/templates/html/js/frame.js
@@ -136,15 +136,17 @@ $(document).ready(function() {
 		e.stopPropagation();
 	});
 	
-	// Update documentation div and create links
-	$('#doctgt').text($('#docsrc').text());
+	// Update documentation div with markdown
+	var converter = new showdown.Converter();
+	$('#doctgt').html(converter.makeHtml($('#docsrc').text()));
 	
-	if(typeof $('#doctgt').html() !== "undefined") {
-	   $('#doctgt').html($('#doctgt').html()
-		  .replace(/(\w+:\/\/\S+)/g, '<a href="$1" target="_blank">$1</a>')
-		  .replace(/mailto:(\S+)/g, '<a href="mailto:$1">$1</a>')
-	   );
-	}
+	// TODO: either remove, or update the regex to deal with trailing </p> tags
+	// if(typeof $('#doctgt').html() !== "undefined") {
+	//    $('#doctgt').html($('#doctgt').html()
+	// 	  .replace(/(\w+:\/\/\S+)/g, '<a href="$1" target="_blank">$1</a>')
+	// 	  .replace(/mailto:(\S+)/g, '<a href="mailto:$1">$1</a>')
+	//    );
+	// }
 	
 	// Replace Hint URL
 	for (var id in hints) {

--- a/com.archimatetool.reports/templates/st/frame.stg
+++ b/com.archimatetool.reports/templates/st/frame.stg
@@ -141,6 +141,7 @@ frame(element, map) ::= <<
 	<!-- REPORT SPECIFIC -->
 	<link type="text/css" rel="stylesheet" href="../../css/model.css">
 	<link type="text/css" rel="stylesheet" href="../../css/i18n.css">
+	<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/showdown@1.9.0/dist/showdown.min.js"></script>
 	<script type="text/javascript" src="../../js/frame.js"></script>
 	<script type="text/javascript" src="../../js/imageMapResizer.min.js"></script>
 </head>


### PR DESCRIPTION
This is a work-in-progress pull request to tackle https://github.com/archimatetool/archi/issues/293

I've chosen the easy Javascript route, rather than the (for me) complicated Java route. As a result the Markdown parsing is not present in the Archi UI itself, or in Jasper reports.

I'm interested in your feedback.

The results of this change:
![Screenshot from 2019-11-20 22-40-14](https://user-images.githubusercontent.com/7458098/69280576-fe985080-0be6-11ea-8431-163de84dd602.png)
![Screenshot from 2019-11-20 22-40-37](https://user-images.githubusercontent.com/7458098/69280577-fe985080-0be6-11ea-92d1-793f6f287ec3.png)

