### PR TITLE
[Features] Duplicate View Folder

### DIFF
--- a/com.archimatetool.model/src/com/archimatetool/model/IFolder.java
+++ b/com.archimatetool.model/src/com/archimatetool/model/IFolder.java
@@ -26,7 +26,7 @@ import org.eclipse.emf.ecore.EObject;
  * @model
  * @generated
  */
-public interface IFolder extends IArchimateModelObject, IFolderContainer, IDocumentable, IProperties {
+public interface IFolder extends IArchimateModelObject, IFolderContainer, IDocumentable, IProperties, ICloneable {
     /**
      * Returns the value of the '<em><b>Elements</b></em>' containment reference list.
      * The list contents are of type {@link org.eclipse.emf.ecore.EObject}.

--- a/com.archimatetool.model/src/com/archimatetool/model/impl/Folder.java
+++ b/com.archimatetool.model/src/com/archimatetool/model/impl/Folder.java
@@ -23,6 +23,7 @@ import org.eclipse.emf.ecore.util.InternalEList;
 
 import com.archimatetool.model.FolderType;
 import com.archimatetool.model.IAdapter;
+import com.archimatetool.model.IArchimateFactory;
 import com.archimatetool.model.IArchimateModel;
 import com.archimatetool.model.IArchimateModelObject;
 import com.archimatetool.model.IArchimatePackage;
@@ -646,12 +647,12 @@ public class Folder extends EObjectImpl implements IFolder {
 
     @Override
     public EObject getCopy() {
-    	IFolder newFolder = EcoreUtil.copy(this);
+        IFolder newFolder = EcoreUtil.copy(this);
+    	newFolder.setName(this.getName());
     	newFolder.setId(UUIDFactory.createID(newFolder)); // New Id to be set
     	newFolder.getFolders().clear(); // this is required
     	newFolder.getElements().clear(); // This is required
-    	
-    	// TODO: probably still missing some things here
+        
     	return newFolder;
     }
     

--- a/com.archimatetool.model/src/com/archimatetool/model/impl/Folder.java
+++ b/com.archimatetool.model/src/com/archimatetool/model/impl/Folder.java
@@ -18,6 +18,7 @@ import org.eclipse.emf.ecore.InternalEObject;
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
 import org.eclipse.emf.ecore.impl.EObjectImpl;
 import org.eclipse.emf.ecore.util.EObjectContainmentEList;
+import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.ecore.util.InternalEList;
 
 import com.archimatetool.model.FolderType;
@@ -25,6 +26,7 @@ import com.archimatetool.model.IAdapter;
 import com.archimatetool.model.IArchimateModel;
 import com.archimatetool.model.IArchimateModelObject;
 import com.archimatetool.model.IArchimatePackage;
+import com.archimatetool.model.IDiagramModel;
 import com.archimatetool.model.IDocumentable;
 import com.archimatetool.model.IFeature;
 import com.archimatetool.model.IFeatures;
@@ -642,4 +644,15 @@ public class Folder extends EObjectImpl implements IFolder {
         return result.toString();
     }
 
+    @Override
+    public EObject getCopy() {
+    	IFolder newFolder = EcoreUtil.copy(this);
+    	newFolder.setId(UUIDFactory.createID(newFolder)); // New Id to be set
+    	newFolder.getFolders().clear(); // this is required
+    	newFolder.getElements().clear(); // This is required
+    	
+    	// TODO: probably still missing some things here
+    	return newFolder;
+    }
+    
 } //Folder


### PR DESCRIPTION
I added a small feature : allowing Archi to Duplicate a folder of Views

The use case is to have a Project Template of Views, and being allowed to duplicate this full folder

Initialy I thought that just adding DuplicateDiagramFolderCommand would work pretty well, I was so wrong ...

We have to move everything that is duplicated from its original folder to the new one (no matter a duplicated sub folder or duplicated sub diagram) 
1. We thus need to get the duplicated folder / diagram -> I added a "getCopiedDiagram" in the DuplicateDiagramModelCommand
2.  I wanted to use the 2 existings MoveCommands ... but when we create the commands and analyze what we have to copy ... we don't yet have the new destination ... so I had to add 2 commands DuplicatedFolderMoveCommand / DuplicatedDiagramMoveCommand to manage this. I am still quite happy because it is just a front to the MoveCommand, and the execute are called after the objects are created 👍  

There are still cleaning things to do, but I need some help : 
- The most obvious is that I check if the folder is in the "Views" subfolder ... and I check directly by name instead of using the Message strings. but since it is in another class .. I don't know how what would be the best way to do it 
- This check must also be in the proper class. But I'm not sure of the impact to check (meaning adding it to the correct interface ?)
- I am sure you will find many other bad details 