### PR TITLE
Zoom slider bug fix

### DIFF
--- a/com.archimatetool.reports/templates/html/js/frame.js
+++ b/com.archimatetool.reports/templates/html/js/frame.js
@@ -168,7 +168,7 @@ $(document).ready(function() {
 		parent.window.postMessage('view-id=' + viewId, '*');
 
 		// *** DIAGRAM ZOOM ***
-		initZoomSlider();
+		window.addEventListener('load', initZoomSlider);
 	}
 
 	function initZoomSlider() {


### PR DESCRIPTION
It fixes the problem reported by @YoeriVD
Now using window.load event instead