### PR TITLE
Add Invert Connection Direction feature for ArchiMate diagrams

### DIFF
--- a/com.archimatetool.editor/plugin.properties
+++ b/com.archimatetool.editor/plugin.properties
@@ -98,6 +98,7 @@ command.name.31 = Text Position Top
 command.name.32 = Text Position Centre
 command.name.33 = Text Position Bottom
 command.name.34 = Select Objects of Same Type
+command.name.35 = Invert Connection Direction
 
 command.description = Show Archi Plug-ins
 command.description.0 = Zoom to Actual Size
@@ -134,6 +135,7 @@ command.description.31 = Set text position of objects to top
 command.description.32 = Set text position of objects to centre
 command.description.33 = Set text position of objects to bottom
 command.description.34 = Select objects of the same type in a diagram
+command.description.35 = Invert the direction of selected connections
 
 keyword.label = model tree files view filter search folder
 keyword.label.1 = layout grid view palette sketch background legend

--- a/com.archimatetool.editor/plugin.xml
+++ b/com.archimatetool.editor/plugin.xml
@@ -1005,6 +1005,12 @@
             name="%command.name.34">
       </command>
       <command
+            categoryId="org.eclipse.ui.category.edit"
+            description="%command.description.35"
+            id="com.archimatetool.editor.action.invertConnection"
+            name="%command.name.35">
+      </command>
+      <command
             categoryId="org.eclipse.gef.category.view"
             description="%command.description.22"
             id="com.archimatetool.editor.bringToFront"

--- a/com.archimatetool.editor/src/com/archimatetool/editor/diagram/ArchimateDiagramEditor.java
+++ b/com.archimatetool.editor/src/com/archimatetool/editor/diagram/ArchimateDiagramEditor.java
@@ -23,6 +23,7 @@ import org.eclipse.ui.PlatformUI;
 import com.archimatetool.editor.ArchiPlugin;
 import com.archimatetool.editor.diagram.actions.DeleteFromModelAction;
 import com.archimatetool.editor.diagram.actions.GenerateViewAction;
+import com.archimatetool.editor.diagram.actions.InvertConnectionAction;
 import com.archimatetool.editor.diagram.actions.ViewpointAction;
 import com.archimatetool.editor.diagram.dnd.ArchimateDiagramTransferDropTargetListener;
 import com.archimatetool.editor.diagram.editparts.ArchimateDiagramEditPartFactory;
@@ -169,7 +170,12 @@ implements IArchimateDiagramEditor {
         action = new DeleteFromModelAction(this);
         registry.registerAction(action);
         getSelectionActions().add(action.getId());
-        
+
+        // Invert Connection Direction
+        action = new InvertConnectionAction(this);
+        registry.registerAction(action);
+        getSelectionActions().add(action.getId());
+
         // Viewpoints
         for(IViewpoint viewPoint : ViewpointManager.INSTANCE.getAllViewpoints()) {
             action = new ViewpointAction(this, viewPoint);

--- a/com.archimatetool.editor/src/com/archimatetool/editor/diagram/ArchimateDiagramEditorActionBarContributor.java
+++ b/com.archimatetool.editor/src/com/archimatetool/editor/diagram/ArchimateDiagramEditorActionBarContributor.java
@@ -13,6 +13,7 @@ import org.eclipse.ui.actions.RetargetAction;
 
 import com.archimatetool.editor.actions.ArchiActionFactory;
 import com.archimatetool.editor.diagram.actions.DeleteFromModelAction;
+import com.archimatetool.editor.diagram.actions.InvertConnectionAction;
 import com.archimatetool.model.viewpoints.IViewpoint;
 import com.archimatetool.model.viewpoints.ViewpointManager;
 
@@ -34,7 +35,12 @@ extends AbstractDiagramEditorActionBarContributor {
         RetargetAction retargetAction = new RetargetAction(DeleteFromModelAction.ID, DeleteFromModelAction.TEXT);
         retargetAction.setActionDefinitionId(DeleteFromModelAction.ID);
         addRetargetAction(retargetAction);
-        
+
+        // Invert Connection Direction
+        retargetAction = new RetargetAction(InvertConnectionAction.ID, InvertConnectionAction.TEXT);
+        retargetAction.setActionDefinitionId(InvertConnectionAction.ID);
+        addRetargetAction(retargetAction);
+
         // Viewpoints
         for(IViewpoint viewPoint : ViewpointManager.INSTANCE.getAllViewpoints()) {
             retargetAction = new RetargetAction(viewPoint.toString(), viewPoint.getName(), IAction.AS_RADIO_BUTTON);

--- a/com.archimatetool.editor/src/com/archimatetool/editor/diagram/ArchimateDiagramEditorContextMenuProvider.java
+++ b/com.archimatetool.editor/src/com/archimatetool/editor/diagram/ArchimateDiagramEditorContextMenuProvider.java
@@ -14,6 +14,7 @@ import org.eclipse.jface.action.Separator;
 
 import com.archimatetool.editor.actions.ArchiActionFactory;
 import com.archimatetool.editor.diagram.actions.DeleteFromModelAction;
+import com.archimatetool.editor.diagram.actions.InvertConnectionAction;
 import com.archimatetool.model.viewpoints.IViewpoint;
 import com.archimatetool.model.viewpoints.ViewpointManager;
 
@@ -49,7 +50,10 @@ public class ArchimateDiagramEditorContextMenuProvider extends AbstractDiagramEd
 
         // Delete from Model
         menu.appendToGroup(GROUP_EDIT, actionRegistry.getAction(DeleteFromModelAction.ID));
-        
+
+        // Invert Connection Direction
+        menu.appendToGroup(GROUP_EDIT, actionRegistry.getAction(InvertConnectionAction.ID));
+
         // Generate View For Element
         menu.appendToGroup(GROUP_RENAME, actionRegistry.getAction(ArchiActionFactory.GENERATE_VIEW.getId()));
 

--- a/com.archimatetool.editor/src/com/archimatetool/editor/diagram/actions/InvertConnectionAction.java
+++ b/com.archimatetool.editor/src/com/archimatetool/editor/diagram/actions/InvertConnectionAction.java
@@ -1,0 +1,83 @@
+/**
+ * This program and the accompanying materials
+ * are made available under the terms of the License
+ * which accompanies this distribution in the file LICENSE.txt
+ */
+package com.archimatetool.editor.diagram.actions;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.gef.EditPart;
+import org.eclipse.gef.commands.CompoundCommand;
+import org.eclipse.gef.ui.actions.SelectionAction;
+import org.eclipse.ui.IWorkbenchPart;
+
+import com.archimatetool.editor.diagram.commands.InvertConnectionCommand;
+import com.archimatetool.model.IArchimateRelationship;
+import com.archimatetool.model.IDiagramModelArchimateConnection;
+import com.archimatetool.model.util.ArchimateModelUtils;
+
+
+/**
+ * Invert Connection Direction Action
+ *
+ * Inverts the direction of selected ArchiMate connections by swapping source and target.
+ */
+public class InvertConnectionAction extends SelectionAction {
+
+    public static final String ID = "com.archimatetool.editor.action.invertConnection"; //$NON-NLS-1$
+    public static final String TEXT = Messages.InvertConnectionAction_0;
+
+    public InvertConnectionAction(IWorkbenchPart part) {
+        super(part);
+        setText(TEXT);
+        setId(ID);
+        setActionDefinitionId(ID);
+    }
+
+    @Override
+    protected boolean calculateEnabled() {
+        return !getValidRelationships().isEmpty();
+    }
+
+    @Override
+    public void run() {
+        Set<IArchimateRelationship> relationships = getValidRelationships();
+        if(relationships.isEmpty()) {
+            return;
+        }
+
+        CompoundCommand compoundCommand = new CompoundCommand(TEXT);
+        for(IArchimateRelationship relationship : relationships) {
+            compoundCommand.add(new InvertConnectionCommand(relationship));
+        }
+
+        execute(compoundCommand);
+    }
+
+    private Set<IArchimateRelationship> getValidRelationships() {
+        Set<IArchimateRelationship> result = new HashSet<>();
+
+        for(Object object : getSelectedObjects()) {
+            if(!(object instanceof EditPart editPart && editPart.getModel() instanceof IDiagramModelArchimateConnection connection)) {
+                continue;
+            }
+
+            IArchimateRelationship relationship = connection.getArchimateRelationship();
+
+            // Skip if null or already validated — avoids redundant matrix lookup
+            if(relationship == null || result.contains(relationship)) {
+                continue;
+            }
+
+            // Check if the inverted relationship would be valid
+            if(ArchimateModelUtils.isValidRelationship(relationship.getTarget().eClass(),
+                    relationship.getSource().eClass(), relationship.eClass())) {
+                result.add(relationship);
+            }
+        }
+
+        return result;
+    }
+}

--- a/com.archimatetool.editor/src/com/archimatetool/editor/diagram/actions/Messages.java
+++ b/com.archimatetool.editor/src/com/archimatetool/editor/diagram/actions/Messages.java
@@ -164,6 +164,8 @@ public class Messages extends NLS {
     public static String ViewpointAction_0;
 
     public static String ZoomNormalAction_0;
+
+    public static String InvertConnectionAction_0;
     static {
         // initialize resource bundle
         NLS.initializeMessages(BUNDLE_NAME, Messages.class);

--- a/com.archimatetool.editor/src/com/archimatetool/editor/diagram/actions/messages.properties
+++ b/com.archimatetool.editor/src/com/archimatetool/editor/diagram/actions/messages.properties
@@ -106,3 +106,5 @@ ToggleSnapToAlignmentGuidesAction_0=Snap to Alignment Guides
 ViewpointAction_0=Viewpoint
 
 ZoomNormalAction_0=Actual Size
+
+InvertConnectionAction_0=Invert Connection Direction

--- a/com.archimatetool.editor/src/com/archimatetool/editor/diagram/commands/InvertConnectionCommand.java
+++ b/com.archimatetool.editor/src/com/archimatetool/editor/diagram/commands/InvertConnectionCommand.java
@@ -1,0 +1,144 @@
+/**
+ * This program and the accompanying materials
+ * are made available under the terms of the License
+ * which accompanies this distribution in the file LICENSE.txt
+ */
+package com.archimatetool.editor.diagram.commands;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.gef.commands.Command;
+
+import com.archimatetool.model.IArchimateConcept;
+import com.archimatetool.model.IArchimateRelationship;
+import com.archimatetool.model.IConnectable;
+import com.archimatetool.model.IDiagramModelArchimateConnection;
+import com.archimatetool.model.IDiagramModelBendpoint;
+import com.archimatetool.model.IDiagramModelConnection;
+
+
+/**
+ * Invert Connection Direction Command
+ *
+ * Inverts the direction of an IArchimateRelationship and all its referencing diagram connections,
+ * swapping source and target, reversing bendpoints, and swapping text position.
+ */
+public class InvertConnectionCommand extends Command {
+
+    private IArchimateRelationship fRelationship;
+
+    // Saved state for undo
+    private IArchimateConcept fOldSource;
+    private IArchimateConcept fOldTarget;
+    private List<ConnectionState> fConnectionStates;
+
+    private record ConnectionState(IDiagramModelArchimateConnection connection, IConnectable source, IConnectable target, int textPosition,
+            List<int[]> bendpoints) {
+    }
+
+    public InvertConnectionCommand(IArchimateRelationship relationship) {
+        if(relationship == null) {
+            throw new IllegalArgumentException();
+        }
+
+        fRelationship = relationship;
+        setLabel(Messages.InvertConnectionCommand_0);
+    }
+
+    @Override
+    public void execute() {
+        // Save state
+        fOldSource = fRelationship.getSource();
+        fOldTarget = fRelationship.getTarget();
+
+        fConnectionStates = new ArrayList<>();
+        for(IDiagramModelArchimateConnection connection : fRelationship.getReferencingDiagramConnections()) {
+            List<int[]> bendpoints = new ArrayList<>();
+            for(IDiagramModelBendpoint bp : connection.getBendpoints()) {
+                bendpoints.add(new int[] { bp.getStartX(), bp.getStartY(), bp.getEndX(), bp.getEndY() });
+            }
+            fConnectionStates.add(new ConnectionState(connection, connection.getSource(), connection.getTarget(), connection.getTextPosition(), bendpoints));
+        }
+
+        doInvert();
+    }
+
+    @Override
+    public void redo() {
+        doInvert();
+    }
+
+    @Override
+    public void undo() {
+        // Restore relationship source/target
+        fRelationship.connect(fOldSource, fOldTarget);
+
+        // Restore each diagram connection
+        for(ConnectionState state : fConnectionStates) {
+            state.connection().connect(state.source(), state.target());
+            state.connection().setTextPosition(state.textPosition());
+
+            // Restore bendpoints
+            List<IDiagramModelBendpoint> bps = state.connection().getBendpoints();
+            for(int i = 0; i < bps.size(); i++) {
+                int[] saved = state.bendpoints().get(i);
+                IDiagramModelBendpoint bp = bps.get(i);
+                bp.setStartX(saved[0]);
+                bp.setStartY(saved[1]);
+                bp.setEndX(saved[2]);
+                bp.setEndY(saved[3]);
+            }
+        }
+    }
+
+    private void doInvert() {
+        // Swap source/target on the relationship
+        fRelationship.connect(fOldTarget, fOldSource);
+
+        // Swap source/target on each diagram connection and adjust bendpoints/text position
+        for(ConnectionState state : fConnectionStates) {
+            state.connection().connect(state.target(), state.source());
+
+            // Reverse bendpoints: reverse order and swap start↔end coordinates
+            List<IDiagramModelBendpoint> bps = state.connection().getBendpoints();
+            int size = bps.size();
+
+            if(size > 0) {
+                // Read current values into temp array
+                int[][] values = new int[size][4];
+                for(int i = 0; i < size; i++) {
+                    IDiagramModelBendpoint bp = bps.get(i);
+                    values[i] = new int[] { bp.getStartX(), bp.getStartY(), bp.getEndX(), bp.getEndY() };
+                }
+
+                // Write them back in reverse order with start↔end swapped
+                for(int i = 0; i < size; i++) {
+                    IDiagramModelBendpoint bp = bps.get(i);
+                    int[] reversed = values[size - 1 - i];
+                    bp.setStartX(reversed[2]); // old endX
+                    bp.setStartY(reversed[3]); // old endY
+                    bp.setEndX(reversed[0]);   // old startX
+                    bp.setEndY(reversed[1]);   // old startY
+                }
+            }
+
+            // Swap text position: SOURCE↔TARGET, MIDDLE stays
+            int textPos = state.connection().getTextPosition();
+            if(textPos == IDiagramModelConnection.CONNECTION_TEXT_POSITION_SOURCE) {
+                state.connection().setTextPosition(IDiagramModelConnection.CONNECTION_TEXT_POSITION_TARGET);
+            }
+            else if(textPos == IDiagramModelConnection.CONNECTION_TEXT_POSITION_TARGET) {
+                state.connection().setTextPosition(IDiagramModelConnection.CONNECTION_TEXT_POSITION_SOURCE);
+            }
+        }
+    }
+
+    @Override
+    public void dispose() {
+        fRelationship = null;
+        fOldSource = null;
+        fOldTarget = null;
+        fConnectionStates = null;
+    }
+}

--- a/com.archimatetool.editor/src/com/archimatetool/editor/diagram/commands/Messages.java
+++ b/com.archimatetool.editor/src/com/archimatetool/editor/diagram/commands/Messages.java
@@ -74,6 +74,8 @@ public class Messages extends NLS {
     public static String TextAlignmentCommand_0;
 
     public static String TextPositionCommand_0;
+
+    public static String InvertConnectionCommand_0;
     static {
         // initialize resource bundle
         NLS.initializeMessages(BUNDLE_NAME, Messages.class);

--- a/com.archimatetool.editor/src/com/archimatetool/editor/diagram/commands/messages.properties
+++ b/com.archimatetool.editor/src/com/archimatetool/editor/diagram/commands/messages.properties
@@ -50,3 +50,5 @@ TextAlignmentCommand_0=Change Text Alignment
 
 TextPositionCommand_0=Change Text Position
 
+InvertConnectionCommand_0=Invert Connection Direction
+


### PR DESCRIPTION
 ## Summary

  Adds "Invert Connection Direction" action for ArchiMate diagrams (with a ctrl+i, cmd+i shortcuts)

  ## Changes

- InvertConnectionCommand: New GEF command that inverts an IArchimateRelationship and all its
- referencing diagram connections — swaps source/target, reverses bendpoints, and swaps text position.
- Fully supports undo/redo.
- InvertConnectionAction: New SelectionAction that validates selected connections against the ArchiMate relationship matrix, deduplicates by underlying relationship, and executes a CompoundCommand for batch inversion. Greyed out when no valid inversions exist.
- ArchimateDiagramEditor: Registers the action in createActions()
- ArchimateDiagramEditorActionBarContributor: Adds retarget action in buildActions()
- ArchimateDiagramEditorContextMenuProvider: Adds entry to the right-click context menu
- plugin.xml: Adds command definition and Ctrl+I / Cmd+I key binding in the diagram context
