### PR TITLE
Fix comparator contract violation in AlphanumericComparator

### DIFF
--- a/com.archimatetool.editor.tests/src/com/archimatetool/editor/ui/components/AlphanumericComparatorTests.java
+++ b/com.archimatetool.editor.tests/src/com/archimatetool/editor/ui/components/AlphanumericComparatorTests.java
@@ -1,0 +1,125 @@
+/**
+ * This program and the accompanying materials
+ * are made available under the terms of the License
+ * which accompanies this distribution in the file LICENSE.txt
+ */
+package com.archimatetool.editor.ui.components;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.text.Collator;
+
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("nls")
+public class AlphanumericComparatorTests {
+
+    private final AlphanumericComparator cmp =
+            new AlphanumericComparator(Collator.getInstance());
+
+
+    @Test
+    public void testBasicNumericCompare() {
+
+        assertTrue(cmp.compare("1", "2") < 0);
+        assertTrue(cmp.compare("9", "10") < 0);
+        assertTrue(cmp.compare("10", "2") > 0);
+        assertTrue(cmp.compare("100", "99") > 0);
+
+        assertEquals(0, cmp.compare("42", "42"));
+    }
+
+
+    @Test
+    public void testLeadingZeros() {
+
+        assertTrue(cmp.compare("7", "07") < 0);
+        assertTrue(cmp.compare("07", "007") < 0);
+
+        assertEquals(0, cmp.compare("000", "000"));
+    }
+
+
+    @Test
+    public void testSimpleAlphanumericLabels() {
+
+        assertTrue(cmp.compare("file2", "file10") < 0);
+        assertTrue(cmp.compare("actor 9", "actor 10") < 0);
+
+        assertTrue(cmp.compare("Comparator test actor 2", "Comparator test actor 10") < 0);
+    }
+
+
+    @Test
+    public void testHierarchicalPrefixesWithDots() {
+
+        assertTrue(cmp.compare("1.2 Name", "1.10 Name") < 0);
+        assertTrue(cmp.compare("1.2 Name", "1.2.1 Name") < 0);
+        assertTrue(cmp.compare("1.2.1 Name", "1.10 Name") < 0);
+        assertTrue(cmp.compare("2.1.1 Name", "2.1.1.1 Name") < 0);
+        assertTrue(cmp.compare("2.1.1.1 Name", "2.1.2 Name") < 0);
+    }
+
+
+    @Test
+    public void testHierarchicalPrefixesWithDashes() {
+
+        assertTrue(cmp.compare("1-2 Name", "1-10 Name") < 0);
+        assertTrue(cmp.compare("1-2 Name", "1-2-1 Name") < 0);
+        assertTrue(cmp.compare("1-2-1 Name", "1-10 Name") < 0);
+        assertTrue(cmp.compare("2-1-1 Name", "2-1-1-1 Name") < 0);
+        assertTrue(cmp.compare("2-1-1-1 Name", "2-1-2 Name") < 0);
+    }
+
+
+    @Test
+    public void testMixedSeparators() {
+
+        assertTrue(cmp.compare("1.2", "1-10") < 0);
+        assertTrue(cmp.compare("1-2", "1.2.1") < 0);
+        assertTrue(cmp.compare("1_2", "1-10") < 0);
+        assertTrue(cmp.compare("2/1/1", "2.1.1.1") < 0);
+    }
+
+
+    @Test
+    public void testParentBeforeChildOrdering() {
+
+        assertTrue(cmp.compare("1", "1.1") < 0);
+        assertTrue(cmp.compare("1.1", "1.1.1") < 0);
+        assertTrue(cmp.compare("1-1", "1-1-1") < 0);
+        assertTrue(cmp.compare("2.1.1", "2.1.1.1") < 0);
+    }
+
+
+    @Test
+    public void testDeepHierarchyOrdering() {
+
+        assertTrue(cmp.compare("1.2", "1.10") < 0);
+        assertTrue(cmp.compare("1.2", "1.2.1") < 0);
+        assertTrue(cmp.compare("1.2.1", "1.2.2") < 0);
+        assertTrue(cmp.compare("1.2.2", "1.2.10") < 0);
+        assertTrue(cmp.compare("1.2.10", "1.10") < 0);
+    }
+
+
+    @Test
+    public void testRealisticArchimateLabels() {
+
+        /*
+         * Realistic labels taken from existing ArchiMate models
+         * including hierarchical prefixes, parentheses and mixed separators.
+         */
+
+        assertTrue(cmp.compare("(1.1) Receive quotation", "(1.2) Approve quotation") < 0);
+        assertTrue(cmp.compare("(1.2) Approve quotation", "(2.1) Execute works") < 0);
+        assertTrue(cmp.compare("(2.2) Follow up works", "(3.1) Receive invoice") < 0);
+        assertTrue(cmp.compare("(3.1) Receive invoice", "(3.2) Pay invoice") < 0);
+
+        assertTrue(cmp.compare("1-1 Digital Customer Management", "1.2 Data Analysis") < 0);
+        assertTrue(cmp.compare("1.2 Data Analysis", "1-3 Product Management") < 0);
+        assertTrue(cmp.compare("1-3 Product Management", "1.5 Productise Open Source Software") < 0);
+    }
+
+}

--- a/com.archimatetool.editor/src/com/archimatetool/editor/ui/components/AlphanumericComparator.java
+++ b/com.archimatetool.editor/src/com/archimatetool/editor/ui/components/AlphanumericComparator.java
@@ -8,9 +8,13 @@ package com.archimatetool.editor.ui.components;
 import java.util.Comparator;
 
 /**
- * Comparator that sorts strings with numbers so that "file 2" comes before "file 10".
- * Also supports hierarchical numeric prefixes such as "1.2", "1-2-3", etc.,
- * and ensures deterministic ordering for labels with numeric prefixes.
+ * Comparator that performs deterministic alphanumeric sorting so that
+ * strings containing numbers are ordered in a natural way
+ * (for example "file 2" before "file 10").
+ * 
+ * Supports hierarchical numeric prefixes using any separator
+ * (for example "1.2", "1-2-3", "2.1.10", etc.) and ensures
+ * consistent ordering for labels with structured numeric prefixes.
  *
  * @author Phillip Beauvoir
  * @author Franky De Pestel

--- a/com.archimatetool.editor/src/com/archimatetool/editor/ui/components/AlphanumericComparator.java
+++ b/com.archimatetool.editor/src/com/archimatetool/editor/ui/components/AlphanumericComparator.java
@@ -6,18 +6,17 @@
 package com.archimatetool.editor.ui.components;
 
 import java.util.Comparator;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
- * Comparator that sorts strings with numbers in so "file 2" comes before "file 10"
- * 
+ * Comparator that sorts strings with numbers so that "file 2" comes before "file 10".
+ * Also supports hierarchical numeric prefixes such as "1.2", "1-2-3", etc.,
+ * and ensures deterministic ordering for labels with numeric prefixes.
+ *
  * @author Phillip Beauvoir
+ * @author Franky De Pestel
  */
 @SuppressWarnings("nls")
 public class AlphanumericComparator implements Comparator<String> {
-    
-    private static final Pattern HIERARCHY_PATTERN = Pattern.compile("^(\\d+(?:[^0-9]+\\d+)*)([^0-9]+)(.*)$");
 
     private Comparator<? super String> comparator;
 
@@ -200,12 +199,73 @@ public class AlphanumericComparator implements Comparator<String> {
     }
 
     private HierarchyLabel parseHierarchyLabel(String s) {
-        Matcher matcher = HIERARCHY_PATTERN.matcher(s);
-        if(!matcher.matches()) {
+        int len = s.length();
+        int i = 0;
+
+        while(i < len && Character.isWhitespace(s.charAt(i))) {
+            i++;
+        }
+
+        boolean hasOpeningParen = i < len && s.charAt(i) == '(';
+        if(hasOpeningParen) {
+            i++;
+        }
+
+        int pathStart = i;
+
+        if(i >= len || !Character.isDigit(s.charAt(i))) {
             return null;
         }
 
-        return new HierarchyLabel(matcher.group(1), matcher.group(3));
+        boolean hasMultipleSegments = false;
+
+        while(true) {
+            int segmentStart = i;
+
+            while(i < len && Character.isDigit(s.charAt(i))) {
+                i++;
+            }
+
+            if(segmentStart == i) {
+                return null;
+            }
+
+            int separatorStart = i;
+
+            while(i < len && !Character.isDigit(s.charAt(i))) {
+                i++;
+            }
+
+            if(separatorStart == i) {
+                break;
+            }
+
+            if(i < len && Character.isDigit(s.charAt(i))) {
+                hasMultipleSegments = true;
+                continue;
+            }
+
+            String path = s.substring(pathStart, separatorStart);
+            String remainder = s.substring(separatorStart).trim();
+
+            if(hasOpeningParen && remainder.startsWith(")")) {
+                remainder = remainder.substring(1).trim();
+            }
+
+            return hasMultipleSegments ? new HierarchyLabel(path, remainder) : null;
+        }
+
+        String path = s.substring(pathStart, i);
+        String remainder = ""; //$NON-NLS-1$
+
+        if(hasOpeningParen && i < len && s.charAt(i) == ')') {
+            remainder = s.substring(i + 1).trim();
+        }
+        else if(i < len) {
+            remainder = s.substring(i).trim();
+        }
+
+        return hasMultipleSegments ? new HierarchyLabel(path, remainder) : null;
     }
 
     private static final class HierarchyLabel {

--- a/com.archimatetool.editor/src/com/archimatetool/editor/ui/components/AlphanumericComparator.java
+++ b/com.archimatetool.editor/src/com/archimatetool/editor/ui/components/AlphanumericComparator.java
@@ -17,7 +17,7 @@ import java.util.regex.Pattern;
 @SuppressWarnings("nls")
 public class AlphanumericComparator implements Comparator<String> {
     
-    private static final Pattern PATTERN = Pattern.compile("(\\d+)");
+    private static final Pattern HIERARCHY_PATTERN = Pattern.compile("^(\\d+(?:[^0-9]+\\d+)*)([^0-9]+)(.*)$");
 
     private Comparator<? super String> comparator;
 
@@ -27,29 +27,194 @@ public class AlphanumericComparator implements Comparator<String> {
 
     @Override
     public int compare(String s1, String s2) {
-        Matcher m1 = PATTERN.matcher(s1);
-        Matcher m2 = PATTERN.matcher(s2);
-        int pos1 = 0, pos2 = 0;
+        HierarchyLabel h1 = parseHierarchyLabel(s1);
+        HierarchyLabel h2 = parseHierarchyLabel(s2);
 
-        while(m1.find() && m2.find()) {
-            // Compare non-numeric prefixes
-            int cmpPrefix = comparator.compare(s1.substring(pos1, m1.start()), s2.substring(pos2, m2.start()));
-            if(cmpPrefix != 0) {
-                return cmpPrefix;
+        if(h1 != null && h2 != null) {
+            int cmp = compareHierarchyPaths(h1.path, h2.path);
+            if(cmp != 0) {
+                return cmp;
             }
 
-            // Compare numeric parts
-            int num1 = Integer.parseInt(m1.group());
-            int num2 = Integer.parseInt(m2.group());
-            if(num1 != num2) {
-                return Integer.compare(num1, num2);
+            cmp = compareAlphanumericText(h1.remainder, h2.remainder);
+            if(cmp != 0) {
+                return cmp;
             }
 
-            pos1 = m1.end();
-            pos2 = m2.end();
+            return comparator.compare(s1, s2);
         }
-        
-        // Compare remaining parts
-        return comparator.compare(s1.substring(pos1), s2.substring(pos2));
+
+        return compareAlphanumericText(s1, s2);
+    }
+
+    private int compareHierarchyPaths(String path1, String path2) {
+        int i1 = 0;
+        int i2 = 0;
+        int len1 = path1.length();
+        int len2 = path2.length();
+
+        while(i1 < len1 && i2 < len2) {
+            int start1 = i1;
+            int start2 = i2;
+
+            while(i1 < len1 && Character.isDigit(path1.charAt(i1))) {
+                i1++;
+            }
+            while(i2 < len2 && Character.isDigit(path2.charAt(i2))) {
+                i2++;
+            }
+
+            int cmp = compareNumberTokens(path1.substring(start1, i1), path2.substring(start2, i2));
+            if(cmp != 0) {
+                return cmp;
+            }
+
+            int sepStart1 = i1;
+            int sepStart2 = i2;
+
+            while(i1 < len1 && !Character.isDigit(path1.charAt(i1))) {
+                i1++;
+            }
+            while(i2 < len2 && !Character.isDigit(path2.charAt(i2))) {
+                i2++;
+            }
+
+            boolean hasSeparator1 = sepStart1 < i1;
+            boolean hasSeparator2 = sepStart2 < i2;
+
+            boolean hasNextNumber1 = i1 < len1 && Character.isDigit(path1.charAt(i1));
+            boolean hasNextNumber2 = i2 < len2 && Character.isDigit(path2.charAt(i2));
+
+            if(hasSeparator1 && hasNextNumber1 && hasSeparator2 && hasNextNumber2) {
+                continue;
+            }
+
+            if(hasSeparator1 && hasNextNumber1) {
+                return 1;
+            }
+            if(hasSeparator2 && hasNextNumber2) {
+                return -1;
+            }
+
+            break;
+        }
+
+        if(i1 < len1) {
+            return 1;
+        }
+        if(i2 < len2) {
+            return -1;
+        }
+
+        return 0;
+    }
+
+    private int compareAlphanumericText(String s1, String s2) {
+        int i1 = 0;
+        int i2 = 0;
+        int len1 = s1.length();
+        int len2 = s2.length();
+
+        while(i1 < len1 && i2 < len2) {
+            char c1 = s1.charAt(i1);
+            char c2 = s2.charAt(i2);
+
+            if(Character.isDigit(c1) && Character.isDigit(c2)) {
+                int start1 = i1;
+                int start2 = i2;
+
+                while(i1 < len1 && Character.isDigit(s1.charAt(i1))) {
+                    i1++;
+                }
+                while(i2 < len2 && Character.isDigit(s2.charAt(i2))) {
+                    i2++;
+                }
+
+                String token1 = s1.substring(start1, i1);
+                String token2 = s2.substring(start2, i2);
+
+                int cmp = compareNumberTokens(token1, token2);
+                if(cmp != 0) {
+                    return cmp;
+                }
+            }
+            else {
+                int start1 = i1;
+                int start2 = i2;
+
+                while(i1 < len1 && !Character.isDigit(s1.charAt(i1))) {
+                    i1++;
+                }
+                while(i2 < len2 && !Character.isDigit(s2.charAt(i2))) {
+                    i2++;
+                }
+
+                String token1 = s1.substring(start1, i1);
+                String token2 = s2.substring(start2, i2);
+
+                int cmp = comparator.compare(token1, token2);
+                if(cmp != 0) {
+                    return cmp;
+                }
+            }
+        }
+
+        if(i1 < len1) {
+            return 1;
+        }
+        if(i2 < len2) {
+            return -1;
+        }
+
+        return comparator.compare(s1, s2);
+    }
+
+    private int compareNumberTokens(String s1, String s2) {
+        String n1 = stripLeadingZeros(s1);
+        String n2 = stripLeadingZeros(s2);
+
+        if(n1.length() != n2.length()) {
+            return n1.length() - n2.length();
+        }
+
+        int cmp = n1.compareTo(n2);
+        if(cmp != 0) {
+            return cmp;
+        }
+
+        if(s1.length() != s2.length()) {
+            return s1.length() - s2.length();
+        }
+
+        return 0;
+    }
+
+    private String stripLeadingZeros(String s) {
+        int i = 0;
+
+        while(i < s.length() - 1 && s.charAt(i) == '0') {
+            i++;
+        }
+
+        return s.substring(i);
+    }
+
+    private HierarchyLabel parseHierarchyLabel(String s) {
+        Matcher matcher = HIERARCHY_PATTERN.matcher(s);
+        if(!matcher.matches()) {
+            return null;
+        }
+
+        return new HierarchyLabel(matcher.group(1), matcher.group(3));
+    }
+
+    private static final class HierarchyLabel {
+        private final String path;
+        private final String remainder;
+
+        private HierarchyLabel(String path, String remainder) {
+            this.path = path;
+            this.remainder = remainder;
+        }
     }
 }

--- a/com.archimatetool.editor/src/com/archimatetool/editor/views/tree/TreeModelViewer.java
+++ b/com.archimatetool.editor/src/com/archimatetool/editor/views/tree/TreeModelViewer.java
@@ -7,7 +7,6 @@ package com.archimatetool.editor.views.tree;
 
 import java.text.Collator;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,7 +42,6 @@ import com.archimatetool.editor.preferences.IPreferenceConstants;
 import com.archimatetool.editor.ui.ArchiLabelProvider;
 import com.archimatetool.editor.ui.FontFactory;
 import com.archimatetool.editor.ui.ThemeUtils;
-import com.archimatetool.editor.ui.components.AlphanumericComparator;
 import com.archimatetool.editor.ui.components.TreeTextCellEditor;
 import com.archimatetool.editor.ui.textrender.TextRenderer;
 import com.archimatetool.editor.utils.StringUtils;
@@ -59,9 +57,6 @@ import com.archimatetool.model.IDiagramModel;
 import com.archimatetool.model.IFolder;
 import com.archimatetool.model.INameable;
 import com.archimatetool.model.IProfile;
-
-
-
 
 /**
  * Tree Viewer for Model Tree View
@@ -122,45 +117,7 @@ public class TreeModelViewer extends TreeViewer {
         setDisplayIncrementally(limit);
         
         // Sort
-        setComparator(new ViewerComparator(Collator.getInstance()) {
-            Comparator<String> alphanumericComparator = new AlphanumericComparator(getComparator());
-            
-            @Override
-            public int compare(Viewer viewer, Object e1, Object e2) {
-                int cat1 = category(e1);
-                int cat2 = category(e2);
-
-                if(cat1 != cat2) {
-                    return cat1 - cat2;
-                }
-                
-                // Only user folders are sorted
-                if((e1 instanceof IFolder folder1 && e2 instanceof IFolder folder2) && (folder1.getType() != FolderType.USER 
-                        || folder2.getType() != FolderType.USER)) {
-                    return 0;
-                }
-                
-                // Get rendered text or name
-                String label1 = getAncestorFolderRenderText((IArchimateModelObject)e1);
-                if(label1 == null) {
-                    label1 = StringUtils.safeString(ArchiLabelProvider.INSTANCE.getLabelNormalised(e1));
-                }
-
-                // Get rendered text or name
-                String label2 = getAncestorFolderRenderText((IArchimateModelObject)e2);
-                if(label2 == null) {
-                    label2 = StringUtils.safeString(ArchiLabelProvider.INSTANCE.getLabelNormalised(e2));
-                }
-                
-                // Use either alphanumeric compare or default
-                return useAlphanumericComparator ? alphanumericComparator.compare(label1, label2) : getComparator().compare(label1, label2);
-            }
-            
-            @Override
-            public int category(Object element) {
-                return element instanceof IFolder ? 0 : 1;
-            }
-        });
+        setComparator(new CanonicalViewerComparator(Collator.getInstance()));
         
         // Cell Editor
         TreeTextCellEditor cellEditor = new TreeTextCellEditor(getTree());
@@ -415,6 +372,106 @@ public class TreeModelViewer extends TreeViewer {
         return null;
     }
     
+    private String buildInternalSortLabel(Object obj) {
+        if(obj instanceof IArchimateModelObject modelObject) {
+            String label = getAncestorFolderRenderText(modelObject);
+            if(label == null) {
+                label = StringUtils.safeString(ArchiLabelProvider.INSTANCE.getLabelNormalised(obj));
+            }
+            return label;
+        }
+        
+        return StringUtils.safeString(String.valueOf(obj));
+    }
+    
+    private String buildVisibleTreeText(Object element) {
+        String text = element instanceof IArchimateModelObject modelObject ? getAncestorFolderRenderText(modelObject) : null;
+        if(text != null) {
+            return text;
+        }
+        
+        String name = ArchiLabelProvider.INSTANCE.getLabelNormalised(element);
+        
+        // If a dirty model show asterisk
+        if(element instanceof IArchimateModel model && IEditorModelManager.INSTANCE.isModelDirty(model)) {
+            name = "*" + name; //$NON-NLS-1$
+        }
+        // If a relationship show source and target
+        else if(element instanceof IArchimateRelationship relationship) {
+            name += " ("; //$NON-NLS-1$
+            name += ArchiLabelProvider.INSTANCE.getLabelNormalised(relationship.getSource());
+            name += " - "; //$NON-NLS-1$
+            name += ArchiLabelProvider.INSTANCE.getLabelNormalised(relationship.getTarget());
+            name += ")"; //$NON-NLS-1$
+        }
+        
+        return name;
+    }
+    
+    private String buildCanonicalSortKey(Object obj) {
+        StringBuilder sb = new StringBuilder();
+        
+        String internalLabel = buildInternalSortLabel(obj);
+        sb.append(normalizeSortText(internalLabel, useAlphanumericComparator));
+        sb.append('|');
+        
+        String visibleText = buildVisibleTreeText(obj);
+        sb.append(normalizeSortText(visibleText, useAlphanumericComparator));
+        sb.append('|');
+        
+        sb.append(obj.getClass().getName());
+        sb.append('|');
+        
+        if(obj instanceof IArchimateModelObject modelObject) {
+            sb.append(StringUtils.safeString(modelObject.getId()));
+        }
+        else {
+            sb.append(StringUtils.safeString(String.valueOf(obj)));
+        }
+        
+        return sb.toString();
+    }
+    
+    private String normalizeSortText(String text, boolean alphanumeric) {
+        text = StringUtils.safeString(text).trim();
+        
+        if(text.isEmpty()) {
+            return text;
+        }
+        
+        StringBuilder sb = new StringBuilder();
+        int len = text.length();
+        int i = 0;
+        
+        while(i < len) {
+            char ch = text.charAt(i);
+            
+            if(alphanumeric && Character.isDigit(ch)) {
+                int j = i + 1;
+                while(j < len && Character.isDigit(text.charAt(j))) {
+                    j++;
+                }
+                
+                String digits = text.substring(i, j);
+                
+                sb.append('[');
+                for(int k = digits.length(); k < 12; k++) {
+                    sb.append('0');
+                }
+                sb.append(digits);
+                sb.append(']');
+                
+                i = j;
+            }
+            else {
+                sb.append(Character.toLowerCase(ch));
+                i++;
+            }
+        }
+        
+        return sb.toString();
+    }
+    
     /**
      * Get the root expanded elements in case the DrillDownAdapter is active.
      * Note that some of these elements might have been deleted when the tree was drilled into.
@@ -423,6 +480,38 @@ public class TreeModelViewer extends TreeViewer {
      */
     Object[] getRootVisibleExpandedElements() {
         return rootVisibleExpandedElements != null ? rootVisibleExpandedElements : getVisibleExpandedElements();
+    }
+    
+    private class CanonicalViewerComparator extends ViewerComparator {
+        public CanonicalViewerComparator(Collator collator) {
+            super(collator);
+        }
+        
+        @Override
+        public int compare(Viewer viewer, Object e1, Object e2) {
+            int cat1 = category(e1);
+            int cat2 = category(e2);
+
+            if(cat1 != cat2) {
+                return cat1 - cat2;
+            }
+            
+            // Only user folders are sorted
+            if((e1 instanceof IFolder folder1 && e2 instanceof IFolder folder2) && (folder1.getType() != FolderType.USER 
+                    || folder2.getType() != FolderType.USER)) {
+                return 0;
+            }
+            
+            String key1 = buildCanonicalSortKey(e1);
+            String key2 = buildCanonicalSortKey(e2);
+            
+            return key1.compareTo(key2);
+        }
+        
+        @Override
+        public int category(Object element) {
+            return element instanceof IFolder ? 0 : 1;
+        }
     }
     
     // ========================= Model Providers =====================================

--- a/com.archimatetool.editor/src/com/archimatetool/editor/views/tree/TreeModelViewer.java
+++ b/com.archimatetool.editor/src/com/archimatetool/editor/views/tree/TreeModelViewer.java
@@ -7,6 +7,7 @@ package com.archimatetool.editor.views.tree;
 
 import java.text.Collator;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,6 +43,7 @@ import com.archimatetool.editor.preferences.IPreferenceConstants;
 import com.archimatetool.editor.ui.ArchiLabelProvider;
 import com.archimatetool.editor.ui.FontFactory;
 import com.archimatetool.editor.ui.ThemeUtils;
+import com.archimatetool.editor.ui.components.AlphanumericComparator;
 import com.archimatetool.editor.ui.components.TreeTextCellEditor;
 import com.archimatetool.editor.ui.textrender.TextRenderer;
 import com.archimatetool.editor.utils.StringUtils;
@@ -57,6 +59,9 @@ import com.archimatetool.model.IDiagramModel;
 import com.archimatetool.model.IFolder;
 import com.archimatetool.model.INameable;
 import com.archimatetool.model.IProfile;
+
+
+
 
 /**
  * Tree Viewer for Model Tree View
@@ -117,7 +122,45 @@ public class TreeModelViewer extends TreeViewer {
         setDisplayIncrementally(limit);
         
         // Sort
-        setComparator(new CanonicalViewerComparator(Collator.getInstance()));
+        setComparator(new ViewerComparator(Collator.getInstance()) {
+            Comparator<String> alphanumericComparator = new AlphanumericComparator(getComparator());
+            
+            @Override
+            public int compare(Viewer viewer, Object e1, Object e2) {
+                int cat1 = category(e1);
+                int cat2 = category(e2);
+
+                if(cat1 != cat2) {
+                    return cat1 - cat2;
+                }
+                
+                // Only user folders are sorted
+                if((e1 instanceof IFolder folder1 && e2 instanceof IFolder folder2) && (folder1.getType() != FolderType.USER 
+                        || folder2.getType() != FolderType.USER)) {
+                    return 0;
+                }
+                
+                // Get rendered text or name
+                String label1 = getAncestorFolderRenderText((IArchimateModelObject)e1);
+                if(label1 == null) {
+                    label1 = StringUtils.safeString(ArchiLabelProvider.INSTANCE.getLabelNormalised(e1));
+                }
+
+                // Get rendered text or name
+                String label2 = getAncestorFolderRenderText((IArchimateModelObject)e2);
+                if(label2 == null) {
+                    label2 = StringUtils.safeString(ArchiLabelProvider.INSTANCE.getLabelNormalised(e2));
+                }
+                
+                // Use either alphanumeric compare or default
+                return useAlphanumericComparator ? alphanumericComparator.compare(label1, label2) : getComparator().compare(label1, label2);
+            }
+            
+            @Override
+            public int category(Object element) {
+                return element instanceof IFolder ? 0 : 1;
+            }
+        });
         
         // Cell Editor
         TreeTextCellEditor cellEditor = new TreeTextCellEditor(getTree());
@@ -372,106 +415,6 @@ public class TreeModelViewer extends TreeViewer {
         return null;
     }
     
-    private String buildInternalSortLabel(Object obj) {
-        if(obj instanceof IArchimateModelObject modelObject) {
-            String label = getAncestorFolderRenderText(modelObject);
-            if(label == null) {
-                label = StringUtils.safeString(ArchiLabelProvider.INSTANCE.getLabelNormalised(obj));
-            }
-            return label;
-        }
-        
-        return StringUtils.safeString(String.valueOf(obj));
-    }
-    
-    private String buildVisibleTreeText(Object element) {
-        String text = element instanceof IArchimateModelObject modelObject ? getAncestorFolderRenderText(modelObject) : null;
-        if(text != null) {
-            return text;
-        }
-        
-        String name = ArchiLabelProvider.INSTANCE.getLabelNormalised(element);
-        
-        // If a dirty model show asterisk
-        if(element instanceof IArchimateModel model && IEditorModelManager.INSTANCE.isModelDirty(model)) {
-            name = "*" + name; //$NON-NLS-1$
-        }
-        // If a relationship show source and target
-        else if(element instanceof IArchimateRelationship relationship) {
-            name += " ("; //$NON-NLS-1$
-            name += ArchiLabelProvider.INSTANCE.getLabelNormalised(relationship.getSource());
-            name += " - "; //$NON-NLS-1$
-            name += ArchiLabelProvider.INSTANCE.getLabelNormalised(relationship.getTarget());
-            name += ")"; //$NON-NLS-1$
-        }
-        
-        return name;
-    }
-    
-    private String buildCanonicalSortKey(Object obj) {
-        StringBuilder sb = new StringBuilder();
-        
-        String internalLabel = buildInternalSortLabel(obj);
-        sb.append(normalizeSortText(internalLabel, useAlphanumericComparator));
-        sb.append('|');
-        
-        String visibleText = buildVisibleTreeText(obj);
-        sb.append(normalizeSortText(visibleText, useAlphanumericComparator));
-        sb.append('|');
-        
-        sb.append(obj.getClass().getName());
-        sb.append('|');
-        
-        if(obj instanceof IArchimateModelObject modelObject) {
-            sb.append(StringUtils.safeString(modelObject.getId()));
-        }
-        else {
-            sb.append(StringUtils.safeString(String.valueOf(obj)));
-        }
-        
-        return sb.toString();
-    }
-    
-    private String normalizeSortText(String text, boolean alphanumeric) {
-        text = StringUtils.safeString(text).trim();
-        
-        if(text.isEmpty()) {
-            return text;
-        }
-        
-        StringBuilder sb = new StringBuilder();
-        int len = text.length();
-        int i = 0;
-        
-        while(i < len) {
-            char ch = text.charAt(i);
-            
-            if(alphanumeric && Character.isDigit(ch)) {
-                int j = i + 1;
-                while(j < len && Character.isDigit(text.charAt(j))) {
-                    j++;
-                }
-                
-                String digits = text.substring(i, j);
-                
-                sb.append('[');
-                for(int k = digits.length(); k < 12; k++) {
-                    sb.append('0');
-                }
-                sb.append(digits);
-                sb.append(']');
-                
-                i = j;
-            }
-            else {
-                sb.append(Character.toLowerCase(ch));
-                i++;
-            }
-        }
-        
-        return sb.toString();
-    }
-    
     /**
      * Get the root expanded elements in case the DrillDownAdapter is active.
      * Note that some of these elements might have been deleted when the tree was drilled into.
@@ -480,38 +423,6 @@ public class TreeModelViewer extends TreeViewer {
      */
     Object[] getRootVisibleExpandedElements() {
         return rootVisibleExpandedElements != null ? rootVisibleExpandedElements : getVisibleExpandedElements();
-    }
-    
-    private class CanonicalViewerComparator extends ViewerComparator {
-        public CanonicalViewerComparator(Collator collator) {
-            super(collator);
-        }
-        
-        @Override
-        public int compare(Viewer viewer, Object e1, Object e2) {
-            int cat1 = category(e1);
-            int cat2 = category(e2);
-
-            if(cat1 != cat2) {
-                return cat1 - cat2;
-            }
-            
-            // Only user folders are sorted
-            if((e1 instanceof IFolder folder1 && e2 instanceof IFolder folder2) && (folder1.getType() != FolderType.USER 
-                    || folder2.getType() != FolderType.USER)) {
-                return 0;
-            }
-            
-            String key1 = buildCanonicalSortKey(e1);
-            String key2 = buildCanonicalSortKey(e2);
-            
-            return key1.compareTo(key2);
-        }
-        
-        @Override
-        public int category(Object element) {
-            return element instanceof IFolder ? 0 : 1;
-        }
     }
     
     // ========================= Model Providers =====================================


### PR DESCRIPTION
# Fix comparator contract violation in AlphanumericComparator and improve handling of hierarchical numeric labels
## Summary
This PR fixes an intermittent

java.lang.IllegalArgumentException: Comparison method violates its general contract
that could occur when alphanumeric sorting is enabled in the Model Tree.

The exception seems to occur when multiple comparison steps are combined, resulting in a non-deterministic ordering that violates the comparator contract on recent Java versions.

The fix is implemented in AlphanumericComparator, while keeping TreeModelViewer unchanged.

## Changes
Keep TreeModelViewer unchanged

Update AlphanumericComparator to guarantee a deterministic total order

Avoid integer parsing overflow by comparing numeric tokens safely

Preserve existing behaviour for normal labels

Add explicit support for hierarchical numeric prefixes such as:

Name
1.0.1. Name
2.1.2.6. Name
1-1-3 Name
1_2_3 Name
Hierarchical prefixes are now compared segment-by-segment using numeric comparison, independent of the separator character.

This ensures stable ordering for labels that use dotted, dashed, or other separators.

## Scope note
This PR only updates AlphanumericComparator.

For relationships in the Model Tree, the visible label also includes the rendered source and target text shown as:

label (source - target)
That additional visible context is constructed in TreeModelViewer, not in AlphanumericComparator.

Therefore this PR does not change relationship ordering based on the full visible "(source - target)" text.
Changing that would require modifications in TreeModelViewer and is outside the scope of this fix.

## Notes
Alternative alphanumeric comparator implementations were evaluated, but updating the existing comparator keeps behaviour closer to the current implementation while fixing the contract violation.

Tested on Java 21 with large models and alphanumeric sorting enabled