### PR TITLE
Import Archimate Exchange file supports sourceAttachment and targetAttachment for connections

### DIFF
--- a/org.opengroup.archimate.xmlexchange/src/org/opengroup/archimate/xmlexchange/IXMLExchangeGlobals.java
+++ b/org.opengroup.archimate.xmlexchange/src/org/opengroup/archimate/xmlexchange/IXMLExchangeGlobals.java
@@ -57,6 +57,8 @@ public interface IXMLExchangeGlobals {
     String ELEMENT_NODE = "node";
     String ELEMENT_CONNECTION = "connection";
     String ELEMENT_FILLCOLOR = "fillColor";
+    String ELEMENT_SOURCE_ATTACHMENT = "sourceAttachment";
+    String ELEMENT_TARGET_ATTACHMENT = "targetAttachment";
     String ELEMENT_BENDPOINT = "bendpoint";
     String ELEMENT_LINECOLOR = "lineColor";
     String ELEMENT_FONT = "font";

--- a/org.opengroup.archimate.xmlexchange/src/org/opengroup/archimate/xmlexchange/XMLModelImporter.java
+++ b/org.opengroup.archimate.xmlexchange/src/org/opengroup/archimate/xmlexchange/XMLModelImporter.java
@@ -15,6 +15,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
@@ -923,6 +924,37 @@ public class XMLModelImporter implements IXMLExchangeGlobals {
         }
     }
         
+    private Point getPointFromElement(Element element) throws XMLModelParserException {
+    	String xString = element.getAttributeValue(ATTRIBUTE_X);
+        String yString = element.getAttributeValue(ATTRIBUTE_Y);
+
+        if(!hasValue(xString) || !hasValue(yString)) {
+            throw new XMLModelParserException(Messages.XMLModelImporter_13);
+        }
+        
+    	return new Point(Integer.valueOf(xString), Integer.valueOf(yString));
+    }
+
+    /**
+     *  Add a source or target attachment point as a bendpoint
+     * 
+     */
+    private void addAttachmentpoint(IDiagramModelConnection connection, Element srcElement, Element tgtElement) throws XMLModelParserException {
+       Point srcPoint = getPointFromElement(srcElement);
+       Point tgtPoint = getPointFromElement(tgtElement);
+       
+       int xDistance = tgtPoint.x() - srcPoint.x() != 0 ? (tgtPoint.x() - srcPoint.x()) / 2 : 0;
+       int yDistance = tgtPoint.y() - srcPoint.y() != 0 ? (tgtPoint.y() - srcPoint.y()) / 2 : 0;
+       int x = srcPoint.x() + xDistance;
+       int y = srcPoint.y() + yDistance;
+
+        IDiagramModelBendpoint bendpoint = DiagramModelUtils.createBendPointFromAbsolutePosition(connection, x, y);
+    	if (bendpoint != null) {
+    		connection.getBendpoints().add(bendpoint);
+    	}
+
+    }
+
     /**
      * Add bendpoints
      */
@@ -931,10 +963,25 @@ public class XMLModelImporter implements IXMLExchangeGlobals {
         if(connection.getSource() instanceof IDiagramModelConnection || connection.getTarget() instanceof IDiagramModelConnection) {
             return;
         }
+        
+        Element sourceAttachment = connectionElement.getChild(ELEMENT_SOURCE_ATTACHMENT, ARCHIMATE3_NAMESPACE);
+        Element targetAttachment = connectionElement.getChild(ELEMENT_TARGET_ATTACHMENT, ARCHIMATE3_NAMESPACE);
+        List<Element> bendpoints = connectionElement.getChildren(ELEMENT_BENDPOINT, ARCHIMATE3_NAMESPACE);
+        
+        // Special case: if sourceAttachment and targetAttachment and no bend points then just create one bend point 
+        if (sourceAttachment != null && targetAttachment != null && bendpoints.isEmpty()) {
+        	addAttachmentpoint(connection, sourceAttachment, targetAttachment);
+        	return;
+        }
+        
+        if (sourceAttachment != null && !bendpoints.isEmpty()) {
+        	addAttachmentpoint(connection, sourceAttachment, bendpoints.getFirst());
+        }
 
-        for(Element bendpointElement : connectionElement.getChildren(ELEMENT_BENDPOINT, ARCHIMATE3_NAMESPACE)) {
+        for(Element bendpointElement : bendpoints) {
             String xString = bendpointElement.getAttributeValue(ATTRIBUTE_X);
             String yString = bendpointElement.getAttributeValue(ATTRIBUTE_Y);
+ 
             if(!hasValue(xString) || !hasValue(yString)) {
                 throw new XMLModelParserException(Messages.XMLModelImporter_13);
             }
@@ -947,6 +994,11 @@ public class XMLModelImporter implements IXMLExchangeGlobals {
                 connection.getBendpoints().add(bendpoint);
             }
         }
+        
+        if (targetAttachment != null && !bendpoints.isEmpty()) {
+        	addAttachmentpoint(connection, targetAttachment, bendpoints.getLast());
+        }
+
     }
     
     /**

--- a/tests/org.opengroup.archimate.xmlexchange.tests/src/org/opengroup/archimate/xmlexchange/TestSupport.java
+++ b/tests/org.opengroup.archimate.xmlexchange.tests/src/org/opengroup/archimate/xmlexchange/TestSupport.java
@@ -21,5 +21,6 @@ public class TestSupport {
     public static File TESTDATA_FOLDER = TestUtils.getLocalBundleFolder("org.opengroup.archimate.xmlexchange.tests", "testdata");
     public static File TEST_MODEL_FILE_ARCHISURANCE = new File(TESTDATA_FOLDER, "Archisurance.archimate");
     public static File XML_FILE1 = new File(TESTDATA_FOLDER, "Sample1.xml");
+    public static File XML_BENDPOINT_FILE = new File(TESTDATA_FOLDER, "bendpoint.test.xml");
     
 }

--- a/tests/org.opengroup.archimate.xmlexchange.tests/src/org/opengroup/archimate/xmlexchange/XMLModelImporterTests.java
+++ b/tests/org.opengroup.archimate.xmlexchange.tests/src/org/opengroup/archimate/xmlexchange/XMLModelImporterTests.java
@@ -9,12 +9,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.util.Iterator;
 import java.io.File;
 import java.io.IOException;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.EObject;
 
 import com.archimatetool.editor.model.ModelChecker;
 import com.archimatetool.editor.utils.FileUtils;
@@ -23,6 +27,8 @@ import com.archimatetool.model.IArchimateElement;
 import com.archimatetool.model.IArchimateModel;
 import com.archimatetool.model.IArchimatePackage;
 import com.archimatetool.model.IArchimateRelationship;
+import com.archimatetool.model.IDiagramModel;
+import com.archimatetool.model.IDiagramModelArchimateConnection;
 import com.archimatetool.model.IFolder;
 import com.archimatetool.tests.TestUtils;
 
@@ -96,5 +102,28 @@ public class XMLModelImporterTests {
         // Check Model
         ModelChecker checker = new ModelChecker(model);
         checker.checkAll();
+    }
+    
+    @Test
+    public void testArchimateModelHasConnectionWithBendpoints() throws Exception {
+    	IArchimateModel model = importer.createArchiMateModel(TestSupport.XML_BENDPOINT_FILE);
+    	
+    	EList<IDiagramModel> diagramModels = model.getDiagramModels();
+    	
+    	assertEquals(1, diagramModels.size());
+    	
+    	IDiagramModel dm = diagramModels.get(0);
+    	
+    	assertEquals("View", dm.getName()); //$NON-NLS-1$
+    	
+    	// Each connection should have one bendpoint
+    	for(Iterator<EObject> iter = dm.eAllContents(); iter.hasNext();) {
+            EObject eObject = iter.next();
+            if(eObject instanceof IDiagramModelArchimateConnection) {
+            	var conn= (IDiagramModelArchimateConnection)eObject;
+            	assertEquals(1, conn.getBendpoints().size());
+            }
+        }
+    	
     }
 }

--- a/tests/org.opengroup.archimate.xmlexchange.tests/testdata/bendpoint.test.xml
+++ b/tests/org.opengroup.archimate.xmlexchange.tests/testdata/bendpoint.test.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model xmlns="http://www.opengroup.org/xsd/archimate/3.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengroup.org/xsd/archimate/3.0/ http://www.opengroup.org/xsd/archimate/3.1/archimate3_Diagram.xsd" identifier="id-019dd58b-68f1-7486-8548-1584050b4711">
+    <name xml:lang="en">Bendpoint test</name>
+    <elements>
+        <element identifier="id-019dd58c-fbb9-7f75-8731-7c7b4db67709" xsi:type="BusinessFunction">
+            <name xml:lang="en">Business Function</name>
+        </element>
+        <element identifier="id-019dd58c-3116-731f-a761-905e3234486b" xsi:type="BusinessService">
+            <name xml:lang="en">Business Service</name>
+        </element>
+    </elements>
+    <relationships>
+        <relationship identifier="id-019dd58d-947b-7f8b-9342-69b71072a882" xsi:type="Serving" source="id-019dd58c-3116-731f-a761-905e3234486b" target="id-019dd58c-fbb9-7f75-8731-7c7b4db67709"/>
+        <relationship identifier="id-019dd58d-4fcc-7e5e-a15c-617f4bf97c31" xsi:type="Realization" source="id-019dd58c-fbb9-7f75-8731-7c7b4db67709" target="id-019dd58c-3116-731f-a761-905e3234486b"/>
+    </relationships>
+    <views>
+        <diagrams>
+            <view identifier="id-019dd58b-68f1-765a-bca8-2716884f56b2">
+                <name xml:lang="en">View</name>
+                <node identifier="id-019dd58c-3116-72be-8618-072b804c1e6d" xsi:type="Element" elementRef="id-019dd58c-3116-731f-a761-905e3234486b" x="0" y="0" w="200" h="70" />
+                <node identifier="id-019dd58c-fbb9-73fa-8251-f74d2a8b73f6" xsi:type="Element" elementRef="id-019dd58c-fbb9-7f75-8731-7c7b4db67709" x="0" y="138" w="200" h="70" />
+                <connection identifier="id-019dd58d-4fcc-7b66-bbe6-ad9d4c3efc06" xsi:type="Relationship" relationshipRef="id-019dd58d-4fcc-7e5e-a15c-617f4bf97c31" source="id-019dd58c-fbb9-73fa-8251-f74d2a8b73f6" target="id-019dd58c-3116-72be-8618-072b804c1e6d">
+                    <sourceAttachment x="35" y="138" />
+                    <targetAttachment x="35" y="70" />
+                </connection>
+                <connection identifier="id-019dd58d-947b-7fb9-9542-5bf530b5c326" xsi:type="Relationship" relationshipRef="id-019dd58d-947b-7f8b-9342-69b71072a882" source="id-019dd58c-3116-72be-8618-072b804c1e6d" target="id-019dd58c-fbb9-73fa-8251-f74d2a8b73f6">
+                    <sourceAttachment x="160" y="70" />
+                    <targetAttachment x="160" y="138" />
+                </connection>
+            </view>
+        </diagrams>
+    </views>
+</model>


### PR DESCRIPTION
The XMLModelImporter has been enhanced to recognise sourceAttachment and targetAttachment for connections in diagrams. The attachment points are implemented as bend points.
 
It turns out that if a bend point is located on the edge of the element then the drawing algorithm  will render the connection from the center of the element to the attachment point. If how ever the attachment point is outside the element then the connection is rendering from the edge of the object.

So in order not to make changes to the drawing algorithm then the attachment points will be adjusted so the start and end points is offset by 1. 