### PR TITLE
fix: allow Aggregation/Composition from Grouping/Location to Junction

### DIFF
--- a/com.archimatetool.model/src/com/archimatetool/model/util/ArchimateModelUtils.java
+++ b/com.archimatetool.model/src/com/archimatetool/model/util/ArchimateModelUtils.java
@@ -28,8 +28,10 @@ import com.archimatetool.model.IArchimateModel;
 import com.archimatetool.model.IArchimatePackage;
 import com.archimatetool.model.IArchimateRelationship;
 import com.archimatetool.model.IFolder;
+import com.archimatetool.model.IGrouping;
 import com.archimatetool.model.IIdentifier;
 import com.archimatetool.model.IJunction;
+import com.archimatetool.model.ILocation;
 import com.archimatetool.model.IProfile;
 import com.archimatetool.model.IProfiles;
 
@@ -53,6 +55,9 @@ public class ArchimateModelUtils {
         if(sourceConcept instanceof IJunction) {
             // Has to be the same type of relationship
             for(IArchimateRelationship rel : getAllRelationshipsForConcept(sourceConcept)) {
+                if(isGroupingOrLocationAggregationOrCompositionRelationship(rel.getSource(), rel.eClass())) {
+                    continue;
+                }
                 if(!rel.eClass().equals(relationshipType)) {
                     return false;
                 }
@@ -84,6 +89,9 @@ public class ArchimateModelUtils {
             }
             // Has to be the same type of relationship
             for(IArchimateRelationship rel : getAllRelationshipsForConcept(sourceConcept)) {
+                if(isGroupingOrLocationAggregationOrCompositionRelationship(rel.getSource(), rel.eClass())) {
+                    continue;
+                }
                 if(!rel.eClass().equals(relationshipType)) {
                     return false;
                 }
@@ -92,21 +100,37 @@ public class ArchimateModelUtils {
         
         // If the target concept is a Junction check for valid relationships
         if(targetConcept instanceof IJunction) {
-            // This is an invalid indirect relationship between a concept connected to the Junction and the source concept
-            for(IArchimateRelationship rel : targetConcept.getSourceRelationships()) {
-                if(!isValidRelationship(sourceConcept.eClass(), rel.getTarget().eClass(), relationshipType)) {
-                    return false;
+            // ArchiMate 3 Appendix B: Grouping and Location may have Aggregation or Composition to any concept,
+            // including Junctions, regardless of what other relationship types the Junction already has.
+            // Bypass the Junction homogeneity constraint for these combinations.
+            boolean isStructuralFromGroupingOrLocation = isGroupingOrLocationAggregationOrCompositionRelationship(sourceConcept, relationshipType);
+
+            if(!isStructuralFromGroupingOrLocation) {
+                // This is an invalid indirect relationship between a concept connected to the Junction and the source concept
+                for(IArchimateRelationship rel : targetConcept.getSourceRelationships()) {
+                    if(!isValidRelationship(sourceConcept.eClass(), rel.getTarget().eClass(), relationshipType)) {
+                        return false;
+                    }
                 }
-            }
-            // Has to be the same type of relationship
-            for(IArchimateRelationship rel : getAllRelationshipsForConcept(targetConcept)) {
-                if(!rel.eClass().equals(relationshipType)) {
-                    return false;
+                // Has to be the same type of relationship
+                for(IArchimateRelationship rel : getAllRelationshipsForConcept(targetConcept)) {
+                    if(isGroupingOrLocationAggregationOrCompositionRelationship(rel.getSource(), rel.eClass())) {
+                        continue;
+                    }
+                    if(!rel.eClass().equals(relationshipType)) {
+                        return false;
+                    }
                 }
             }
         }
-        
+
         return isValidRelationship(sourceConcept.eClass(), targetConcept.eClass(), relationshipType);
+    }
+
+    private static boolean isGroupingOrLocationAggregationOrCompositionRelationship(IArchimateConcept sourceConcept, EClass relationshipType) {
+        return (sourceConcept instanceof IGrouping || sourceConcept instanceof ILocation)
+                && (relationshipType == IArchimatePackage.eINSTANCE.getAggregationRelationship()
+                        || relationshipType == IArchimatePackage.eINSTANCE.getCompositionRelationship());
     }
 
     /**

--- a/tests/com.archimatetool.model.tests/src/com/archimatetool/model/util/ArchimateModelUtilsTests.java
+++ b/tests/com.archimatetool.model.tests/src/com/archimatetool/model/util/ArchimateModelUtilsTests.java
@@ -28,7 +28,10 @@ import com.archimatetool.model.IArchimateModel;
 import com.archimatetool.model.IArchimatePackage;
 import com.archimatetool.model.IArchimateRelationship;
 import com.archimatetool.model.IFolder;
+import com.archimatetool.model.IGrouping;
 import com.archimatetool.model.IIdentifier;
+import com.archimatetool.model.IJunction;
+import com.archimatetool.model.ILocation;
 import com.archimatetool.model.IProfile;
 import com.archimatetool.model.IProfiles;
 
@@ -444,4 +447,105 @@ public class ArchimateModelUtilsTests {
         profile2.setName("OSCAR");
         profile2.setConceptType(IArchimatePackage.eINSTANCE.getBusinessRole().getName());
     }
-} 
+
+    // =====================================================================================================
+    // Tests for Grouping/Location -> Aggregation/Composition -> Junction constraint bypass (issue #1229)
+    // =====================================================================================================
+
+    @Test
+    public void testIsValidRelationship_GroupingAggregationToJunctionWithExistingRelationships() {
+        // Grouping -> Aggregation -> Junction that already has a Triggering relationship should be allowed
+        IGrouping grouping = IArchimateFactory.eINSTANCE.createGrouping();
+        IJunction junction = IArchimateFactory.eINSTANCE.createJunction();
+
+        // Give the Junction an existing Triggering relationship (making it a "Triggering Junction")
+        IArchimateElement otherElement = IArchimateFactory.eINSTANCE.createBusinessActor();
+        IArchimateRelationship triggeringRel = IArchimateFactory.eINSTANCE.createTriggeringRelationship();
+        triggeringRel.connect(junction, otherElement);
+
+        // Aggregation from Grouping to this Junction must now be valid despite the type mismatch
+        assertTrue(ArchimateModelUtils.isValidRelationship(grouping, junction,
+                IArchimatePackage.eINSTANCE.getAggregationRelationship()));
+    }
+
+    @Test
+    public void testIsValidRelationship_GroupingCompositionToJunctionWithExistingRelationships() {
+        // Grouping -> Composition -> Junction that already has a Triggering relationship should be allowed
+        IGrouping grouping = IArchimateFactory.eINSTANCE.createGrouping();
+        IJunction junction = IArchimateFactory.eINSTANCE.createJunction();
+
+        IArchimateElement otherElement = IArchimateFactory.eINSTANCE.createBusinessActor();
+        IArchimateRelationship triggeringRel = IArchimateFactory.eINSTANCE.createTriggeringRelationship();
+        triggeringRel.connect(junction, otherElement);
+
+        assertTrue(ArchimateModelUtils.isValidRelationship(grouping, junction,
+                IArchimatePackage.eINSTANCE.getCompositionRelationship()));
+    }
+
+    @Test
+    public void testIsValidRelationship_GroupingCompositionAndBusinessActorAssignmentToJunctionIsOrderIndependent() {
+        IArchimateElement businessActor = IArchimateFactory.eINSTANCE.createBusinessActor();
+        IGrouping grouping = IArchimateFactory.eINSTANCE.createGrouping();
+        IJunction junction = IArchimateFactory.eINSTANCE.createJunction();
+
+        IArchimateRelationship assignmentRel = IArchimateFactory.eINSTANCE.createAssignmentRelationship();
+        assignmentRel.connect(businessActor, junction);
+
+        assertTrue(ArchimateModelUtils.isValidRelationship(grouping, junction,
+                IArchimatePackage.eINSTANCE.getCompositionRelationship()));
+
+        businessActor = IArchimateFactory.eINSTANCE.createBusinessActor();
+        grouping = IArchimateFactory.eINSTANCE.createGrouping();
+        junction = IArchimateFactory.eINSTANCE.createJunction();
+
+        IArchimateRelationship compositionRel = IArchimateFactory.eINSTANCE.createCompositionRelationship();
+        compositionRel.connect(grouping, junction);
+
+        assertTrue(ArchimateModelUtils.isValidRelationship(businessActor, junction,
+                IArchimatePackage.eINSTANCE.getAssignmentRelationship()));
+    }
+
+    @Test
+    public void testIsValidRelationship_LocationAggregationToJunctionWithExistingRelationships() {
+        // Location -> Aggregation -> Junction that already has a Triggering relationship should be allowed
+        ILocation location = IArchimateFactory.eINSTANCE.createLocation();
+        IJunction junction = IArchimateFactory.eINSTANCE.createJunction();
+
+        IArchimateElement otherElement = IArchimateFactory.eINSTANCE.createBusinessActor();
+        IArchimateRelationship triggeringRel = IArchimateFactory.eINSTANCE.createTriggeringRelationship();
+        triggeringRel.connect(junction, otherElement);
+
+        assertTrue(ArchimateModelUtils.isValidRelationship(location, junction,
+                IArchimatePackage.eINSTANCE.getAggregationRelationship()));
+    }
+
+    @Test
+    public void testIsValidRelationship_NonGroupingAggregationToJunctionWithMixedTypes_StillBlocked() {
+        // A regular element -> Aggregation -> Junction that already has a Triggering relationship
+        // should still be blocked (Junction homogeneity preserved for non-Grouping/Location elements)
+        IArchimateElement businessActor = IArchimateFactory.eINSTANCE.createBusinessActor();
+        IJunction junction = IArchimateFactory.eINSTANCE.createJunction();
+
+        IArchimateElement otherElement = IArchimateFactory.eINSTANCE.createBusinessActor();
+        IArchimateRelationship triggeringRel = IArchimateFactory.eINSTANCE.createTriggeringRelationship();
+        triggeringRel.connect(junction, otherElement);
+
+        assertFalse(ArchimateModelUtils.isValidRelationship(businessActor, junction,
+                IArchimatePackage.eINSTANCE.getAggregationRelationship()));
+    }
+
+    @Test
+    public void testIsValidRelationship_JunctionToJunctionWithDifferentType_StillBlocked() {
+        // Junction -> Triggering -> Junction that already has an Association relationship
+        // should still be blocked (normal Junction homogeneity preserved)
+        IJunction sourceJunction = IArchimateFactory.eINSTANCE.createJunction();
+        IJunction targetJunction = IArchimateFactory.eINSTANCE.createJunction();
+
+        IArchimateElement otherElement = IArchimateFactory.eINSTANCE.createBusinessActor();
+        IArchimateRelationship existingRel = IArchimateFactory.eINSTANCE.createAssociationRelationship();
+        existingRel.connect(targetJunction, otherElement);
+
+        assertFalse(ArchimateModelUtils.isValidRelationship(sourceJunction, targetJunction,
+                IArchimatePackage.eINSTANCE.getTriggeringRelationship()));
+    }
+}


### PR DESCRIPTION
## Summary

ArchiMate 3 Appendix B specifies that Grouping and Location may have Aggregation or Composition relationships to any concept, including Junctions. Archi blocked these when the target Junction already participated in other relationship types (e.g., Triggering), due to the Junction homogeneity constraint in `ArchimateModelUtils.isValidRelationship`.

## Why this matters

Users modeling ArchiMate diagrams that include Grouping or Location elements structurally containing a Junction (e.g., grouping a flow pattern) received an incorrect "invalid relationship" error. The tool was non-compliant with the spec for this combination. Reported in #1229.

## Changes

- `ArchimateModelUtils.java`: Add a bypass in the target-Junction homogeneity block (lines 94-107). When the source concept is `IGrouping` or `ILocation` and the relationship type is `AggregationRelationship` or `CompositionRelationship`, skip the Junction type-homogeneity loops and fall through to the `RelationshipsMatrix` check, which already permits these combinations per the ArchiMate 3 matrix.
- `ArchimateModelUtilsTests.java`: Add five JUnit tests covering Grouping/Location + Aggregation/Composition to a Junction with existing Triggering relationships (now valid), plus regression cases confirming Junction homogeneity is still enforced for regular elements and Junction-to-Junction relationships.

Fixes #1229
